### PR TITLE
Vesion 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.1] / 2025-05-31
 ### Features
-- 
+- Support `Autodesk` native bundle with admin privileges.
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 - Support `Autodesk` native bundle with admin privileges.
 - Show list of bundles in table format using `DataTable`.
+- Support to find app by `BundleName` or `AppName`.
+- Show `AppBundle` information in table format.
 ### Updates
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 - Support `Autodesk` native bundle with admin privileges.
 - Show list of bundles in table format using `DataTable`.
+### Updates
+- Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support Console color output in table format in `Admin` as red color.
 ### Updates
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
+- Update uninstall to use `DeleteDirectoryToRecycleBin`.
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.1] / 2025-05-31
 ### Features
 - Support `Autodesk` native bundle with admin privileges.
+- Show list of bundles in table format using `DataTable`.
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support to find app by `BundleName` or `AppName`.
 - Show `AppBundle` information in table format.
 - Support Console color output in table format in `Admin` as red color.
+- Support `ProgramFilesX86` folder for `AutoCAD` bundles.
 ### Updates
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
 - Update uninstall to use `DeleteDirectoryToRecycleBin`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] / 2025-05-31
+### Features
+- 
+### Fixes
+- Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
+
 ## [1.0.0] / 2025-02-17
 ### Features
 - Install/Uninstall bundle.
@@ -15,4 +21,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `DownloadUtils` to support local file.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Show list of bundles in table format using `DataTable`.
 - Support to find app by `BundleName` or `AppName`.
 - Show `AppBundle` information in table format.
+- Support Console color output in table format in `Admin` as red color.
 ### Updates
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
 - Update uninstall to use `UninstallAppBundle` with `RecycleBinUtils`.
 - Add `RecycleBinUtils` with methods to recycle files and folders.
+- Add `AppNameSpace` and `AppUpgradeCode` in the `ApplicationPackage` class.
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support `ProgramFilesX86` folder for `AutoCAD` bundles.
 ### Updates
 - Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
-- Update uninstall to use `DeleteDirectoryToRecycleBin`.
+- Update uninstall to use `UninstallAppBundle` with `RecycleBinUtils`.
+- Add `RecycleBinUtils` with methods to recycle files and folders.
 ### Fixes
 - Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.4</Version>
+		<Version>1.0.1-beta.5</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.1</Version>
+		<Version>1.0.1-beta.2</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.7</Version>
+		<Version>1.0.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-alpha</Version>
+		<Version>1.0.1-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.2</Version>
+		<Version>1.0.1-beta.3</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.6</Version>
+		<Version>1.0.1-beta.7</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.5</Version>
+		<Version>1.0.1-beta.6</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.0</Version>
+		<Version>1.0.1-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta.3</Version>
+		<Version>1.0.1-beta.4</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-rc</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>1.0.1-beta</Version>
+		<Version>1.0.1-beta.1</Version>
 	</PropertyGroup>
 </Project>

--- a/ricaun.AppBundleTool/AppBundle/AccessUtils.cs
+++ b/ricaun.AppBundleTool/AppBundle/AccessUtils.cs
@@ -9,6 +9,16 @@ namespace ricaun.AppBundleTool.AppBundle
     public static class AccessUtils
     {
         /// <summary>
+        /// Checks if the application has both read and write access to the specified file path.
+        /// </summary>
+        /// <param name="filePath">The path of the file to check for read and write access.</param>
+        /// <returns>True if the application can read from and write to the specified file path; otherwise, false.</returns>
+        public static bool CheckReadAndWriteAccess(string filePath)
+        {
+            return CheckFileReadAccess(filePath) && CheckWriteAccess(filePath);
+        }
+
+        /// <summary>
         /// Checks if the application has write access to the specified path.
         /// </summary>
         /// <param name="path">The path to check for write access.</param>
@@ -17,9 +27,37 @@ namespace ricaun.AppBundleTool.AppBundle
         {
             try
             {
+                if (File.Exists(path))
+                    path = Path.GetDirectoryName(path);
+                else if (!Directory.Exists(path))
+                    path = Path.GetDirectoryName(path);
+
                 var fileName = Path.Combine(path, Path.GetRandomFileName());
                 File.Create(fileName).Close();
                 File.Delete(fileName);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the application has read access to the specified file.
+        /// </summary>
+        /// <param name="filePath">The path of the file to check for read access.</param>
+        /// <returns>True if the application can read the specified file; otherwise, false.</returns>
+        public static bool CheckFileReadAccess(string filePath)
+        {
+            try
+            {
+                if (File.Exists(filePath))
+                {
+                    // FileStream throws UnauthorizedAccessException if the file is not accessible for reading
+                    using (FileStream fileStream = new FileStream(filePath, FileMode.Open)) { }
+                }
             }
             catch (Exception)
             {

--- a/ricaun.AppBundleTool/AppBundle/AppBundleAccess.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleAccess.cs
@@ -1,0 +1,8 @@
+﻿namespace ricaun.AppBundleTool.AppBundle
+{
+    public enum AppBundleAccess
+    {
+        Allow,      // Access is permitted
+        Admin       // Access requires administrator privileges
+    }
+}

--- a/ricaun.AppBundleTool/AppBundle/AppBundleAccess.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleAccess.cs
@@ -1,8 +1,18 @@
 ﻿namespace ricaun.AppBundleTool.AppBundle
 {
+    /// <summary>
+    /// Specifies the access level required for app bundle operations.
+    /// </summary>
     public enum AppBundleAccess
     {
-        Allow,      // Access is permitted
-        Admin       // Access requires administrator privileges
+        /// <summary>
+        /// Access is permitted without restrictions.
+        /// </summary>
+        Allow,
+
+        /// <summary>
+        /// Access requires administrator privileges.
+        /// </summary>
+        Admin
     }
 }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleFolder.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleFolder.cs
@@ -5,6 +5,7 @@
         None,
         AppData,
         ProgramData,
-        ProgramFiles
+        ProgramFiles,
+        ProgramFilesX86
     }
 }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleFolderUtils.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleFolderUtils.cs
@@ -13,7 +13,7 @@ namespace ricaun.AppBundleTool.AppBundle
 
             foreach (var specialFolder in specialFolders)
             {
-                var environmentFolder = Environment.GetFolderPath(specialFolder.Value);
+                var environmentFolder = specialFolder.Value.GetApplicationPlugins();
                 if (folder.StartsWith(environmentFolder, StringComparison.InvariantCultureIgnoreCase))
                 {
                     appBundleFolder = specialFolder.Key;
@@ -30,7 +30,8 @@ namespace ricaun.AppBundleTool.AppBundle
             {
                 { AppBundleFolder.AppData, Environment.SpecialFolder.ApplicationData },
                 { AppBundleFolder.ProgramData, Environment.SpecialFolder.CommonApplicationData },
-                { AppBundleFolder.ProgramFiles, Environment.SpecialFolder.ProgramFiles }
+                { AppBundleFolder.ProgramFiles, Environment.SpecialFolder.ProgramFiles },
+                { AppBundleFolder.ProgramFilesX86, Environment.SpecialFolder.ProgramFilesX86 },
             };
         }
 

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
@@ -25,7 +25,7 @@ namespace ricaun.AppBundleTool.AppBundle
             WriteAccess = AccessUtils.CheckReadAndWriteAccess(PathPackageContents);
             AppBundleAccess = WriteAccess ? AppBundleAccess.Allow : AppBundleAccess.Admin;
             ApplicationPackage = ApplicationPackage.Parse(PathPackageContents);
-            ApplicationPackage.Show();
+            //ApplicationPackage.Show();
         }
         public bool IsValid()
         {

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
@@ -21,7 +21,7 @@ namespace ricaun.AppBundleTool.AppBundle
             {
                 AppBundleFolder = appBundleFolder;
             }
-            WriteAccess = AccessUtils.CheckWriteAccess(pathBundle);
+            WriteAccess = AccessUtils.CheckReadAndWriteAccess(PathPackageContents);
             ApplicationPackage = ApplicationPackage.Parse(PathPackageContents);
             ApplicationPackage.Show();
         }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfo.cs
@@ -10,6 +10,7 @@ namespace ricaun.AppBundleTool.AppBundle
         public string PathBundle { get; set; }
         public string PathPackageContents { get; set; }
         public AppBundleFolder AppBundleFolder { get; set; }
+        public AppBundleAccess AppBundleAccess { get; set; }
         public bool WriteAccess { get; set; }
         public ApplicationPackage ApplicationPackage { get; set; }
         public AppBundleInfo(string pathBundle)
@@ -22,6 +23,7 @@ namespace ricaun.AppBundleTool.AppBundle
                 AppBundleFolder = appBundleFolder;
             }
             WriteAccess = AccessUtils.CheckReadAndWriteAccess(PathPackageContents);
+            AppBundleAccess = WriteAccess ? AppBundleAccess.Allow : AppBundleAccess.Admin;
             ApplicationPackage = ApplicationPackage.Parse(PathPackageContents);
             ApplicationPackage.Show();
         }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -1,6 +1,7 @@
 ﻿using ricaun.AppBundleTool.PackageContents;
 using ricaun.AppBundleTool.Utils;
 using System;
+using System.Collections.Generic;
 using System.Data;
 
 namespace ricaun.AppBundleTool.AppBundle
@@ -59,6 +60,24 @@ namespace ricaun.AppBundleTool.AppBundle
             return table;
         }
 
+        public static DataTable[] ToDataTables(this AppBundleInfo appBundleInfo, bool detail = false)
+        {
+            var tables = new List<DataTable>();
+
+            tables.Add(appBundleInfo.ToDataTable(detail));
+
+            if (detail)
+            {
+                foreach (var component in appBundleInfo.ApplicationPackage?.Components)
+                {
+                    if (component is null) continue;
+                    tables.Add(component.ToDataTable());
+                }
+            }
+
+            return tables.ToArray();
+        }
+
         public static DataTable ToDataTable(this AppBundleInfo appBundleInfo, bool detail = false)
         {
             if (appBundleInfo == null) return null;
@@ -75,24 +94,32 @@ namespace ricaun.AppBundleTool.AppBundle
             table.DataRow("AppProductType", appBundleInfo.ApplicationPackage?.ProductType ?? string.Empty);
             table.DataRow("AppProductCode", appBundleInfo.ApplicationPackage?.ProductCode ?? string.Empty);
             table.DataRow("AppCompanyName", appBundleInfo.ApplicationPackage?.CompanyDetails?.Name);
+            if (detail)
+            {
+                table.DataRow("AppNameSpace", appBundleInfo.ApplicationPackage?.AppNameSpace ?? string.Empty);
+                table.DataRow("AppUpgradeCode", appBundleInfo.ApplicationPackage?.UpgradeCode ?? string.Empty);
+            }
             table.DataRow("PathBundle", appBundleInfo.PathBundle);
             table.DataRow("Access", appBundleInfo.AppBundleAccess.ToConsoleString());
 
-            if (detail)
+            return table;
+        }
+
+        public static DataTable ToDataTable(this Component component)
+        {
+            DataTable table = new DataTable();
+            table.CreateDataColumns();
+
+            table.DataRow("Component.Description", component.Description);
+            table.DataRow("Requirements.Platform", component.RuntimeRequirements?.Platform);
+            table.DataRow("Requirements.OS", component.RuntimeRequirements?.OS);
+            table.DataRow("Requirements.SeriesMin", component.RuntimeRequirements?.SeriesMin);
+            table.DataRow("Requirements.SeriesMax", component.RuntimeRequirements?.SeriesMax);
+
+            foreach (var componentEntry in component.ComponentEntry)
             {
-                foreach (var component in appBundleInfo.ApplicationPackage?.Components)
-                {
-                    var componentText = component.RuntimeRequirements.Platform + " " +
-                                        component.RuntimeRequirements.OS + " " +
-                                        component.RuntimeRequirements.SeriesMin + " " +
-                                        component.RuntimeRequirements.SeriesMax;
-                    table.DataRow("Component", componentText);
-                    foreach (var componentEntry in component.ComponentEntry)
-                    {
-                        table.DataRow("ComponentEntry.AppName", componentEntry.AppName);
-                        table.DataRow("ComponentEntry.ModuleName", componentEntry.ModuleName);
-                    }
-                }
+                table.DataRow("ComponentEntry.AppName", componentEntry.AppName);
+                table.DataRow("ComponentEntry.ModuleName", componentEntry.ModuleName);
             }
 
             return table;

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -1,4 +1,5 @@
 ﻿using ricaun.AppBundleTool.PackageContents;
+using ricaun.AppBundleTool.Utils;
 using System;
 using System.Data;
 
@@ -29,7 +30,7 @@ namespace ricaun.AppBundleTool.AppBundle
 
         public static DataTable ToDataTable(this AppBundleInfo[] appBundleInfoArray, bool detail = false)
         {
-            var table = new DataTable("AppBundles");
+            var table = new DataTable();
             table.Columns.Add("Folder", typeof(string));
             table.Columns.Add("Bundle", typeof(string));
             table.Columns.Add("AppName", typeof(string));
@@ -51,15 +52,8 @@ namespace ricaun.AppBundleTool.AppBundle
                 {
                     row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
                 }
-                row["Access"] = appBundleInfo.AppBundleAccess;
-                //if (appBundleInfo.AppBundleAccess == AppBundleAccess.Allow)
-                //{
-                //    //row["Access"] = $"{GREEN}{appBundleInfo.AppBundleAccess}{NORMAL}";
-                //}
-                //else if (appBundleInfo.AppBundleAccess == AppBundleAccess.Admin)
-                //{
-                //    row["Access"] = $"{RED}{appBundleInfo.AppBundleAccess}{NORMAL}";
-                //}
+                row["Access"] = appBundleInfo.AppBundleAccess == AppBundleAccess.Admin ? appBundleInfo.AppBundleAccess.ToConsoleRed() : appBundleInfo.AppBundleAccess;
+
                 table.Rows.Add(row);
             }
             return table;
@@ -69,7 +63,7 @@ namespace ricaun.AppBundleTool.AppBundle
         {
             if (appBundleInfo == null) return null;
 
-            var table = new DataTable("AppBundle");
+            var table = new DataTable();
             table.CreateDataColumns();
 
             table.DataRow("Bundle", appBundleInfo.Name);
@@ -82,7 +76,7 @@ namespace ricaun.AppBundleTool.AppBundle
             table.DataRow("AppProductCode", appBundleInfo.ApplicationPackage?.ProductCode ?? string.Empty);
             table.DataRow("AppCompanyName", appBundleInfo.ApplicationPackage?.CompanyDetails?.Name);
             table.DataRow("PathBundle", appBundleInfo.PathBundle);
-            table.DataRow("Access", appBundleInfo.AppBundleAccess);
+            table.DataRow("Access", appBundleInfo.AppBundleAccess == AppBundleAccess.Admin ? appBundleInfo.AppBundleAccess.ToConsoleRed() : appBundleInfo.AppBundleAccess);
 
             if (detail)
             {

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -1,5 +1,6 @@
 ﻿using ricaun.AppBundleTool.PackageContents;
 using System;
+using System.Data;
 
 namespace ricaun.AppBundleTool.AppBundle
 {
@@ -24,6 +25,36 @@ namespace ricaun.AppBundleTool.AppBundle
                     }
                 }
             }
+        }
+
+        public static DataTable ToDataTable(this AppBundleInfo[] appBundleInfoArray, bool detail = false)
+        {
+            var table = new DataTable("AppBundles");
+            table.Columns.Add("Folder", typeof(string));
+            table.Columns.Add("Bundle", typeof(string));
+            table.Columns.Add("AppName", typeof(string));
+            if (detail)
+            {
+                table.Columns.Add("AppProduct", typeof(string));
+                table.Columns.Add("AppDescription", typeof(string));
+            }
+            table.Columns.Add("Access", typeof(string));
+            foreach (var appBundleInfo in appBundleInfoArray)
+            {
+                if (appBundleInfo == null) continue;
+                var row = table.NewRow();
+                row["Folder"] = appBundleInfo.AppBundleFolder;
+                row["Bundle"] = appBundleInfo.Name;
+                row["AppName"] = appBundleInfo.ApplicationPackage?.Name ?? string.Empty;
+                if (detail)
+                {
+                    row["AppProduct"] = appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty;
+                    row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
+                }
+                row["Access"] = appBundleInfo.AppBundleAccess;
+                table.Rows.Add(row);
+            }
+            return table;
         }
     }
 }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -38,6 +38,7 @@ namespace ricaun.AppBundleTool.AppBundle
             table.Columns.Add("AppProduct", typeof(string));
             if (detail)
             {
+                table.Columns.Add("Company", typeof(string));
                 table.Columns.Add("AppDescription", typeof(string));
             }
             table.Columns.Add("Access", typeof(string));
@@ -51,6 +52,7 @@ namespace ricaun.AppBundleTool.AppBundle
                 row["AppProduct"] = appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty;
                 if (detail)
                 {
+                    row["Company"] = appBundleInfo.ApplicationPackage?.CompanyDetails?.Name ?? string.Empty;
                     row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
                 }
                 row["Access"] = appBundleInfo.AppBundleAccess.ToConsoleString();
@@ -101,6 +103,27 @@ namespace ricaun.AppBundleTool.AppBundle
             }
             table.DataRow("PathBundle", appBundleInfo.PathBundle);
             table.DataRow("Access", appBundleInfo.AppBundleAccess.ToConsoleString());
+
+            //if (detail)
+            //{
+            //    table.DataRow("Components", string.Empty);
+            //    foreach (var component in appBundleInfo.ApplicationPackage?.Components)
+            //    {
+            //        if (component is null) continue;
+
+            //        table.DataRow("Component.Description", component.Description);
+            //        table.DataRow("Requirements.Platform", component.RuntimeRequirements?.Platform);
+            //        table.DataRow("Requirements.OS", component.RuntimeRequirements?.OS);
+            //        table.DataRow("Requirements.SeriesMin", component.RuntimeRequirements?.SeriesMin);
+            //        table.DataRow("Requirements.SeriesMax", component.RuntimeRequirements?.SeriesMax);
+
+            //        foreach (var componentEntry in component.ComponentEntry)
+            //        {
+            //            table.DataRow("ComponentEntry.AppName", componentEntry.AppName);
+            //            table.DataRow("ComponentEntry.ModuleName", componentEntry.ModuleName);
+            //        }
+            //    }
+            //}
 
             return table;
         }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -52,7 +52,7 @@ namespace ricaun.AppBundleTool.AppBundle
                 {
                     row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
                 }
-                row["Access"] = appBundleInfo.AppBundleAccess == AppBundleAccess.Admin ? appBundleInfo.AppBundleAccess.ToConsoleRed() : appBundleInfo.AppBundleAccess;
+                row["Access"] = appBundleInfo.AppBundleAccess.ToConsoleString();
 
                 table.Rows.Add(row);
             }
@@ -76,7 +76,7 @@ namespace ricaun.AppBundleTool.AppBundle
             table.DataRow("AppProductCode", appBundleInfo.ApplicationPackage?.ProductCode ?? string.Empty);
             table.DataRow("AppCompanyName", appBundleInfo.ApplicationPackage?.CompanyDetails?.Name);
             table.DataRow("PathBundle", appBundleInfo.PathBundle);
-            table.DataRow("Access", appBundleInfo.AppBundleAccess == AppBundleAccess.Admin ? appBundleInfo.AppBundleAccess.ToConsoleRed() : appBundleInfo.AppBundleAccess);
+            table.DataRow("Access", appBundleInfo.AppBundleAccess.ToConsoleString());
 
             if (detail)
             {
@@ -96,6 +96,15 @@ namespace ricaun.AppBundleTool.AppBundle
             }
 
             return table;
+        }
+
+        private static string ToConsoleString(this AppBundleAccess appBundleAccess)
+        {
+            return appBundleAccess switch
+            {
+                AppBundleAccess.Admin => appBundleAccess.ToConsoleRed(),
+                _ => appBundleAccess.ToString()
+            };
         }
 
         private static DataTable CreateDataColumns(this DataTable table)

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -38,6 +38,7 @@ namespace ricaun.AppBundleTool.AppBundle
             table.Columns.Add("AppProduct", typeof(string));
             if (detail)
             {
+                table.Columns.Add("AppVersion", typeof(string));
                 table.Columns.Add("Company", typeof(string));
                 table.Columns.Add("AppDescription", typeof(string));
             }
@@ -52,6 +53,7 @@ namespace ricaun.AppBundleTool.AppBundle
                 row["AppProduct"] = appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty;
                 if (detail)
                 {
+                    row["AppVersion"] = appBundleInfo.ApplicationPackage?.AppVersion ?? string.Empty;
                     row["Company"] = appBundleInfo.ApplicationPackage?.CompanyDetails?.Name ?? string.Empty;
                     row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
                 }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleInfoExtension.cs
@@ -33,9 +33,9 @@ namespace ricaun.AppBundleTool.AppBundle
             table.Columns.Add("Folder", typeof(string));
             table.Columns.Add("Bundle", typeof(string));
             table.Columns.Add("AppName", typeof(string));
+            table.Columns.Add("AppProduct", typeof(string));
             if (detail)
             {
-                table.Columns.Add("AppProduct", typeof(string));
                 table.Columns.Add("AppDescription", typeof(string));
             }
             table.Columns.Add("Access", typeof(string));
@@ -46,15 +46,78 @@ namespace ricaun.AppBundleTool.AppBundle
                 row["Folder"] = appBundleInfo.AppBundleFolder;
                 row["Bundle"] = appBundleInfo.Name;
                 row["AppName"] = appBundleInfo.ApplicationPackage?.Name ?? string.Empty;
+                row["AppProduct"] = appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty;
                 if (detail)
                 {
-                    row["AppProduct"] = appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty;
                     row["AppDescription"] = appBundleInfo.ApplicationPackage?.Description ?? string.Empty;
                 }
                 row["Access"] = appBundleInfo.AppBundleAccess;
+                //if (appBundleInfo.AppBundleAccess == AppBundleAccess.Allow)
+                //{
+                //    //row["Access"] = $"{GREEN}{appBundleInfo.AppBundleAccess}{NORMAL}";
+                //}
+                //else if (appBundleInfo.AppBundleAccess == AppBundleAccess.Admin)
+                //{
+                //    row["Access"] = $"{RED}{appBundleInfo.AppBundleAccess}{NORMAL}";
+                //}
                 table.Rows.Add(row);
             }
             return table;
+        }
+
+        public static DataTable ToDataTable(this AppBundleInfo appBundleInfo, bool detail = false)
+        {
+            if (appBundleInfo == null) return null;
+
+            var table = new DataTable("AppBundle");
+            table.CreateDataColumns();
+
+            table.DataRow("Bundle", appBundleInfo.Name);
+            table.DataRow("AppName", appBundleInfo.ApplicationPackage?.Name ?? string.Empty);
+            table.DataRow("AppVersion", appBundleInfo.ApplicationPackage?.AppVersion ?? string.Empty);
+            table.DataRow("AppProduct", appBundleInfo.ApplicationPackage?.AutodeskProduct ?? string.Empty);
+            if (detail)
+                table.DataRow("AppDescription", appBundleInfo.ApplicationPackage?.Description ?? string.Empty);
+            table.DataRow("AppProductType", appBundleInfo.ApplicationPackage?.ProductType ?? string.Empty);
+            table.DataRow("AppProductCode", appBundleInfo.ApplicationPackage?.ProductCode ?? string.Empty);
+            table.DataRow("AppCompanyName", appBundleInfo.ApplicationPackage?.CompanyDetails?.Name);
+            table.DataRow("PathBundle", appBundleInfo.PathBundle);
+            table.DataRow("Access", appBundleInfo.AppBundleAccess);
+
+            if (detail)
+            {
+                foreach (var component in appBundleInfo.ApplicationPackage?.Components)
+                {
+                    var componentText = component.RuntimeRequirements.Platform + " " +
+                                        component.RuntimeRequirements.OS + " " +
+                                        component.RuntimeRequirements.SeriesMin + " " +
+                                        component.RuntimeRequirements.SeriesMax;
+                    table.DataRow("Component", componentText);
+                    foreach (var componentEntry in component.ComponentEntry)
+                    {
+                        table.DataRow("ComponentEntry.AppName", componentEntry.AppName);
+                        table.DataRow("ComponentEntry.ModuleName", componentEntry.ModuleName);
+                    }
+                }
+            }
+
+            return table;
+        }
+
+        private static DataTable CreateDataColumns(this DataTable table)
+        {
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Value", typeof(string));
+            return table;
+        }
+
+        private static DataRow DataRow(this DataTable table, string name, object value)
+        {
+            var row = table.NewRow();
+            row["Name"] = name;
+            row["Value"] = value;
+            table.Rows.Add(row);
+            return row;
         }
     }
 }

--- a/ricaun.AppBundleTool/AppBundle/AppBundleUtils.cs
+++ b/ricaun.AppBundleTool/AppBundle/AppBundleUtils.cs
@@ -15,10 +15,24 @@ namespace ricaun.AppBundleTool.AppBundle
             return Path.Combine(Environment.GetFolderPath(specialFolder), "Autodesk", "ApplicationPlugins");
         }
 
-        public static AppBundleInfo FindAppBundleByName(string appBundleName)
+        public static AppBundleInfo FindAppBundleByAppName(string appBundleName)
         {
+            if (string.IsNullOrWhiteSpace(appBundleName))
+                return null;
+
             var bundles = GetAppBundleFolders();
-            return bundles.Select(e => new AppBundleInfo(e)).FirstOrDefault(e => e.ApplicationPackage?.Name == appBundleName);
+            return bundles.Select(e => new AppBundleInfo(e))
+                .FirstOrDefault(e => appBundleName.Equals(e.ApplicationPackage?.Name, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        public static AppBundleInfo FindAppBundleByBundleName(string bundleName)
+        {
+            if (string.IsNullOrWhiteSpace(bundleName))
+                return null;
+
+            var bundles = GetAppBundleFolders();
+            return bundles.Select(e => new AppBundleInfo(e))
+                .FirstOrDefault(e => e.Name.Equals(bundleName, StringComparison.InvariantCultureIgnoreCase));
         }
 
         /// <summary>

--- a/ricaun.AppBundleTool/PackageContents/ApplicationPackage.cs
+++ b/ricaun.AppBundleTool/PackageContents/ApplicationPackage.cs
@@ -29,6 +29,12 @@ namespace ricaun.AppBundleTool.PackageContents
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the description of the application package.
+        /// </summary>
+        [XmlAttribute]
+        public string Description { get; set; }
+
+        /// <summary>
         /// Gets or sets the version of the application.
         /// </summary>
         [XmlAttribute]
@@ -56,7 +62,7 @@ namespace ricaun.AppBundleTool.PackageContents
         /// Gets or sets the components of the application package.
         /// </summary>
         [XmlElement]
-        public Component[] Components { get; set; }
+        public Component[] Components { get; set; } = new Component[0];
 
         /// <summary>
         /// Parses the application package from the specified XML file.
@@ -68,10 +74,22 @@ namespace ricaun.AppBundleTool.PackageContents
             if (string.IsNullOrWhiteSpace(pathPackageContents)) return null;
             if (!File.Exists(pathPackageContents)) return null;
 
-            XmlSerializer serializer = new XmlSerializer(typeof(ApplicationPackage));
-            using (FileStream fileStream = new FileStream(pathPackageContents, FileMode.Open))
+            try
             {
-                return (ApplicationPackage)serializer.Deserialize(fileStream);
+                XmlSerializer serializer = new XmlSerializer(typeof(ApplicationPackage));
+                using (Stream fileStream = File.OpenRead(pathPackageContents))
+                {
+                    return (ApplicationPackage)serializer.Deserialize(fileStream);
+                }
+            }
+            catch (Exception ex)
+            {
+                var name = Path.GetFileNameWithoutExtension(Path.GetDirectoryName(pathPackageContents));
+                return new ApplicationPackage()
+                {
+                    Name = name,
+                    Description = $"Error parsing ApplicationPackage: {ex.Message}",
+                };
             }
         }
     }

--- a/ricaun.AppBundleTool/PackageContents/ApplicationPackage.cs
+++ b/ricaun.AppBundleTool/PackageContents/ApplicationPackage.cs
@@ -53,6 +53,24 @@ namespace ricaun.AppBundleTool.PackageContents
         public string ProductCode { get; set; }
 
         /// <summary>
+        /// Gets or sets the application namespace associated with the application package.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="AppNameSpace"/> is used in the 'apps.autodesk.com' to identify the application package for upgrades.
+        /// </remarks>
+        [XmlAttribute]
+        public string AppNameSpace { get; set; }
+
+        /// <summary>
+        /// Gets or sets the upgrade code of the application package.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="UpgradeCode"/> is used in the 'apps.autodesk.com' to identify the application package for upgrades.
+        /// </remarks>
+        [XmlAttribute]
+        public string UpgradeCode { get; set; }
+
+        /// <summary>
         /// Gets or sets the company details associated with the application package.
         /// </summary>
         [XmlElement]

--- a/ricaun.AppBundleTool/PackageContents/Component.cs
+++ b/ricaun.AppBundleTool/PackageContents/Component.cs
@@ -24,6 +24,6 @@ namespace ricaun.AppBundleTool.PackageContents
         /// Gets or sets the entries of the component.
         /// </summary>
         [XmlElement]
-        public ComponentEntry[] ComponentEntry { get; set; }
+        public ComponentEntry[] ComponentEntry { get; set; } = new ComponentEntry[0];
     }
 }

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -164,13 +164,16 @@ namespace ricaun.AppBundleTool
                     {
                         table.Print();
                     }
-                    
+
+                    //appBundle.ToDataTable(Verbosity).Print();
+
                     //appBundle.Show();
                 }
             }
             else
             {
-                Console.WriteLine(displayHelp);
+                //Console.WriteLine(displayHelp);
+                Show();
             }
         }
 

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -160,7 +160,11 @@ namespace ricaun.AppBundleTool
                         return;
                     }
 
-                    appBundle.ToDataTable(Verbosity).Print();
+                    foreach (var table in appBundle.ToDataTables(Verbosity))
+                    {
+                        table.Print();
+                    }
+                    
                     //appBundle.Show();
                 }
             }

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -156,7 +156,8 @@ namespace ricaun.AppBundleTool
 
                     if (appBundle is null)
                     {
-                        Console.WriteLine($"AppBundle '{appBundleName}' not found.");
+                        Show();
+                        Console.WriteLine($"AppBundle '{appBundleName}' not found.".ToConsoleYellow());
                         return;
                     }
 
@@ -172,8 +173,8 @@ namespace ricaun.AppBundleTool
             }
             else
             {
-                //Console.WriteLine(displayHelp);
-                Show();
+                Console.WriteLine(displayHelp);
+                //Show();
             }
         }
 

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -59,7 +59,7 @@ namespace ricaun.AppBundleTool
 
                         Console.WriteLine($"Install: {appBundleInfoTemp.ApplicationPackage.AsString()}");
 
-                        var appBundleInstalled = AppBundleUtils.FindAppBundleByName(appBundleName);
+                        var appBundleInstalled = AppBundleUtils.FindAppBundleByAppName(appBundleName);
                         if (appBundleInstalled is not null)
                         {
                             applicationPluginsFolder = appBundleInstalled.AppBundleFolder.GetApplicationPlugins();
@@ -91,7 +91,7 @@ namespace ricaun.AppBundleTool
                         //});
                         Console.WriteLine("---");
                     }
-                    AppBundleUtils.FindAppBundleByName(appBundleName)?.Show();
+                    AppBundleUtils.FindAppBundleByAppName(appBundleName)?.Show();
                 }
                 else if (options.Uninstall)
                 {
@@ -116,7 +116,7 @@ namespace ricaun.AppBundleTool
                         }
                     }
 
-                    var appBundle = AppBundleUtils.FindAppBundleByName(appBundleName);
+                    var appBundle = AppBundleUtils.FindAppBundleByAppName(appBundleName);
                     if (appBundle is null)
                     {
                         Console.WriteLine($"AppBundle '{appBundleName}' not found.");
@@ -134,7 +134,7 @@ namespace ricaun.AppBundleTool
                     {
                         Console.WriteLine($"DownloadApp: {appBundleInfoTemp.ApplicationPackage.AsString()}");
                         appBundleName = appBundleInfoTemp.ApplicationPackage.Name;
-                        var appBundleInfo = AppBundleUtils.FindAppBundleByName(appBundleName);
+                        var appBundleInfo = AppBundleUtils.FindAppBundleByAppName(appBundleName);
                         appBundleInfo?.Show();
                         if (appBundleInfo is null)
                         {
@@ -150,7 +150,7 @@ namespace ricaun.AppBundleTool
                 }
                 else
                 {
-                    var appBundle = AppBundleUtils.FindAppBundleByName(appBundleName);
+                    var appBundle = AppBundleUtils.FindAppBundleByAppName(appBundleName) ?? AppBundleUtils.FindAppBundleByBundleName(appBundleName);
 
                     if (appBundle is null)
                     {
@@ -158,7 +158,8 @@ namespace ricaun.AppBundleTool
                         return;
                     }
 
-                    appBundle.Show();
+                    appBundle.ToDataTable(Verbosity).Print();
+                    //appBundle.Show();
                 }
             }
             else

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -125,7 +125,8 @@ namespace ricaun.AppBundleTool
                     var applicationPluginsFolder = appBundle.AppBundleFolder.GetApplicationPlugins();
                     Console.WriteLine($"Uninstall: {appBundle.ApplicationPackage.AsString()}");
                     //ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, appBundle.Name);
-                    DirectoryUtils.DeleteDirectoryToRecycleBin(appBundle.PathBundle);
+
+                    UninstallAppBundle(appBundle);
                 }
                 else if (Path.GetExtension(appBundleName) == ".zip")
                 {
@@ -166,6 +167,31 @@ namespace ricaun.AppBundleTool
             else
             {
                 Console.WriteLine(displayHelp);
+            }
+        }
+
+        private static void UninstallAppBundle(AppBundleInfo appBundle)
+        {
+            try
+            {
+                RecycleBinUtils.DirectoryToRecycleBin(appBundle.PathBundle);
+                Console.WriteLine($"Send to Recycle Bin: {appBundle.PathBundle}".ToConsoleYellow());
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"Fail to send to Recycle Bin: {appBundle.PathBundle}".ToConsoleRed());
+            }
+
+            try
+            {
+                if (RecycleBinUtils.FileToRecycleBin(appBundle.PathPackageContents))
+                {
+                    Console.WriteLine($"Send to Recycle Bin: {appBundle.PathPackageContents}".ToConsoleYellow());
+                }
+            }
+            catch (Exception)
+            {
+                Console.WriteLine($"Fail to send to Recycle Bin: {appBundle.PathPackageContents}".ToConsoleRed());
             }
         }
 

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -124,7 +124,8 @@ namespace ricaun.AppBundleTool
                     }
                     var applicationPluginsFolder = appBundle.AppBundleFolder.GetApplicationPlugins();
                     Console.WriteLine($"Uninstall: {appBundle.ApplicationPackage.AsString()}");
-                    ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, appBundle.Name);
+                    //ApplicationPluginsUtils.DeleteBundle(applicationPluginsFolder, appBundle.Name);
+                    DirectoryUtils.DeleteDirectoryToRecycleBin(appBundle.PathBundle);
                 }
                 else if (Path.GetExtension(appBundleName) == ".zip")
                 {

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -5,6 +5,7 @@ using ricaun.AppBundleTool.Utils;
 using ricaun.Revit.Installation;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.IO.Compression;
 
@@ -196,11 +197,7 @@ namespace ricaun.AppBundleTool
         public static void Show()
         {
             var appBundles = AppBundleUtils.GetAppBundles();
-
-            foreach (var appBundle in appBundles)
-            {
-                Console.WriteLine(appBundle);
-            }
+            appBundles.ToDataTable(Verbosity).Print();
         }
 
         private static string DisplayHelp<T>(ParserResult<T> result)

--- a/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
+++ b/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
@@ -1,0 +1,67 @@
+﻿using System;
+
+namespace ricaun.AppBundleTool.Utils
+{
+    /// <summary>
+    /// Provides extension methods for formatting strings with console color escape codes.
+    /// </summary>
+    public static class ConsoleColorExtension
+    {
+        internal static int ToConsoleLength(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return 0;
+
+            // Regex to match ANSI escape codes: starts with \x1b[, ends with m
+            var regex = new System.Text.RegularExpressions.Regex(@"\x1b\[[^m]*m");
+            // Remove all ANSI escape codes
+            string cleanText = regex.Replace(text, string.Empty);
+            return cleanText.Length;
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with red console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in red color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleRed(this object value)
+        {
+            return $"{RED}{value}{NORMAL}";
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with green console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in green color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleGreen(this object value)
+        {
+            return $"{GREEN}{value}{NORMAL}";
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with yellow console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in yellow color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleYellow(this object value)
+        {
+            return $"{GREEN}{value}{NORMAL}";
+        }
+
+        static string NORMAL => Console.IsOutputRedirected ? "" : "\x1b[39m";
+        static string RED => Console.IsOutputRedirected ? "" : "\x1b[91m";
+        static string GREEN => Console.IsOutputRedirected ? "" : "\x1b[92m";
+        static string YELLOW => Console.IsOutputRedirected ? "" : "\x1b[93m";
+        static string BLUE => Console.IsOutputRedirected ? "" : "\x1b[94m";
+        static string MAGENTA => Console.IsOutputRedirected ? "" : "\x1b[95m";
+        static string CYAN => Console.IsOutputRedirected ? "" : "\x1b[96m";
+        static string GREY => Console.IsOutputRedirected ? "" : "\x1b[97m";
+        static string BOLD => Console.IsOutputRedirected ? "" : "\x1b[1m";
+        static string NOBOLD => Console.IsOutputRedirected ? "" : "\x1b[22m";
+        static string UNDERLINE => Console.IsOutputRedirected ? "" : "\x1b[4m";
+        static string NOUNDERLINE => Console.IsOutputRedirected ? "" : "\x1b[24m";
+        static string REVERSE => Console.IsOutputRedirected ? "" : "\x1b[7m";
+        static string NOREVERSE => Console.IsOutputRedirected ? "" : "\x1b[27m";
+    }
+}

--- a/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
+++ b/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
@@ -7,15 +7,15 @@ namespace ricaun.AppBundleTool.Utils
     /// </summary>
     public static class ConsoleColorExtension
     {
-        internal static int ToConsoleLength(this string text)
+        internal static int ToConsoleLength(this string value)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(value))
                 return 0;
 
             // Regex to match ANSI escape codes: starts with \x1b[, ends with m
-            var regex = new System.Text.RegularExpressions.Regex(@"\x1b\[[^m]*m");
+            var regex = new System.Text.RegularExpressions.Regex(@"\x1b\[\d+m");
             // Remove all ANSI escape codes
-            string cleanText = regex.Replace(text, string.Empty);
+            string cleanText = regex.Replace(value, string.Empty);
             return cleanText.Length;
         }
 

--- a/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
+++ b/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
@@ -46,8 +46,49 @@ namespace ricaun.AppBundleTool.Utils
         /// <returns>A string wrapped in yellow color escape codes, or the original string if output is redirected.</returns>
         public static string ToConsoleYellow(this object value)
         {
-            return $"{GREEN}{value}{NORMAL}";
+            return $"{YELLOW}{value}{NORMAL}";
         }
+
+        /// <summary>
+        /// Formats the specified value as a string with blue console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in blue color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleBlue(this object value)
+        {
+            return $"{BLUE}{value}{NORMAL}";
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with magenta console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in magenta color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleMagenta(this object value)
+        {
+            return $"{MAGENTA}{value}{NORMAL}";
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with cyan console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in cyan color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleCyan(this object value)
+        {
+            return $"{CYAN}{value}{NORMAL}";
+        }
+
+        /// <summary>
+        /// Formats the specified value as a string with grey console color escape codes.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <returns>A string wrapped in grey color escape codes, or the original string if output is redirected.</returns>
+        public static string ToConsoleGrey(this object value)
+        {
+            return $"{GREY}{value}{NORMAL}";
+        }
+        
 
         static string NORMAL => Console.IsOutputRedirected ? "" : "\x1b[39m";
         static string RED => Console.IsOutputRedirected ? "" : "\x1b[91m";

--- a/ricaun.AppBundleTool/Utils/DirectoryUtils.cs
+++ b/ricaun.AppBundleTool/Utils/DirectoryUtils.cs
@@ -34,5 +34,15 @@ namespace ricaun.AppBundleTool.Utils
                 File.Copy(file, destFile, overwrite);
             }
         }
+
+        internal static void DeleteDirectoryToRecycleBin(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                Microsoft.VisualBasic.FileIO.FileSystem.DeleteDirectory(path, 
+                    Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs, 
+                    Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
+            }
+        }
     }
 }

--- a/ricaun.AppBundleTool/Utils/DirectoryUtils.cs
+++ b/ricaun.AppBundleTool/Utils/DirectoryUtils.cs
@@ -37,12 +37,7 @@ namespace ricaun.AppBundleTool.Utils
 
         internal static void DeleteDirectoryToRecycleBin(string path)
         {
-            if (Directory.Exists(path))
-            {
-                Microsoft.VisualBasic.FileIO.FileSystem.DeleteDirectory(path, 
-                    Microsoft.VisualBasic.FileIO.UIOption.OnlyErrorDialogs, 
-                    Microsoft.VisualBasic.FileIO.RecycleOption.SendToRecycleBin);
-            }
+            RecycleBinUtils.DirectoryToRecycleBin(path);
         }
     }
 }

--- a/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
+++ b/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace ricaun.AppBundleTool.Utils
 {
     /// <summary>
-    /// PrintDataExtensions with basic Console color support
+    /// PrintDataExtensions with basic Console color support (PrintList does not work with Console color)
     /// </summary>
     /// <remarks>
     /// Based:
@@ -527,6 +527,12 @@ namespace ricaun.AppBundleTool.Utils
                 else
                 {
                     str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
+                    if (str.Length != str.GetLength())
+                    {
+                        var extraSpaces = lengths[i] - str.GetLength();
+                        if (extraSpaces > 0)
+                            str += new string(' ', extraSpaces); // Ensure the string is padded to the correct length
+                    }
                 }
 
                 if (lengths[i] < str.GetLength())

--- a/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
+++ b/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
@@ -1,0 +1,1148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace System.Data
+{
+    /// <summary>
+    /// https://github.com/yuvalsol/PrintDataTableToConsole
+    /// https://github.com/yuvalsol/PrintDataTableToConsole/blob/master/PrintData/PrintDataExtensions.cs
+    /// </summary>
+    internal static partial class PrintDataExtensions
+    {
+        #region Print Columns
+
+        public static void PrintColumns(this DataTable dataTable, params string[] columnNames)
+        {
+            PrintColumns(dataTable.TableName, GetColumns(dataTable, columnNames));
+        }
+
+        public static void PrintColumns(this DataView dataView, params string[] columnNames)
+        {
+            PrintColumns(dataView.Table.TableName, GetColumns(dataView.Table, columnNames));
+        }
+
+        public static void PrintColumns(this DataSet dataSet, params string[] columnNames)
+        {
+            foreach (DataTable dataTable in dataSet.Tables)
+                PrintColumns(dataTable, columnNames);
+        }
+
+        private static void PrintColumns(string name, DataColumn[] columns)
+        {
+            string columnName = "Column Name";
+            string dataType = "Data Type";
+            string nullable = "Nullable";
+            string dataMember = "Data Member";
+
+            int length0 = 0;
+            int length1 = columnName.Length;
+            int length2 = dataType.Length;
+            int length3 = nullable.Length;
+            int length4 = dataMember.Length;
+
+            if (columns.Length > 0)
+            {
+                int maxLength = columns.Select(c => c.Ordinal).Max().ToString().Length;
+                if (length0 < maxLength)
+                    length0 = maxLength;
+
+                maxLength = columns.Select(c => c.ColumnName.Length).Max();
+                if (length1 < maxLength)
+                    length1 = maxLength;
+
+                maxLength = columns.Select(c => c.DataType.ToString().Length).Max();
+                if (length2 < maxLength)
+                    length2 = maxLength;
+
+                maxLength = columns.Select(c => GetDataMemberType(c).Length + 1 + c.ColumnName.Length).Max();
+                if (length4 < maxLength)
+                    length4 = maxLength;
+            }
+
+            string horizontal0 = new String(Horizontal_Bar, length0 + 2);
+            string horizontal1 = new String(Horizontal_Bar, length1 + 2);
+            string horizontal2 = new String(Horizontal_Bar, length2 + 2);
+            string horizontal3 = new String(Horizontal_Bar, length3 + 2);
+            string horizontal4 = new String(Horizontal_Bar, length4 + 2);
+
+            if (string.IsNullOrEmpty(name) == false)
+                WriteLine("{0}:", name);
+
+            WriteLine("{5}{0}{6}{1}{6}{2}{6}{3}{6}{4}{7}", horizontal0, horizontal1, horizontal2, horizontal3, horizontal4, Top_Left, Top_Center, Top_Right);
+
+            string format1 = string.Format("{{5}} {{0,-{0}}} {{5}} {{1,-{1}}} {{5}} {{2,-{2}}} {{5}} {{3,-{3}}} {{5}} {{4,-{4}}} {{5}}", length0, length1, length2, length3, length4);
+            WriteLine(format1, string.Empty, columnName, dataType, nullable, dataMember, Verticl_Bar);
+
+            WriteLine("{5}{0}{6}{1}{6}{2}{6}{3}{6}{4}{7}", horizontal0, horizontal1, horizontal2, horizontal3, horizontal4, Middle_Left, Middle_Center, Middle_Right);
+
+            foreach (DataColumn column in columns)
+            {
+                string dataMemberType = GetDataMemberType(column);
+                string format2 = string.Format("{{5}} {{0,{0}}} {{5}} {{1,-{1}}} {{5}} {{2,-{2}}} {{5}} {{3,-{3}}} {{5}} {{4}} {{1}} {{5,{4}}}", length0, length1, length2, length3, length4 - dataMemberType.Length - column.ColumnName.Length);
+                WriteLine(format2, column.Ordinal, column.ColumnName, column.DataType, column.AllowDBNull, dataMemberType, Verticl_Bar);
+            }
+
+            WriteLine("{5}{0}{6}{1}{6}{2}{6}{3}{6}{4}{7}", horizontal0, horizontal1, horizontal2, horizontal3, horizontal4, Bottom_Left, Bottom_Center, Bottom_Right);
+
+            WriteLine();
+        }
+
+        private static string GetDataMemberType(DataColumn column)
+        {
+            if (column.DataType == typeof(string))
+                return "string";
+            else if (column.DataType == typeof(int))
+                return "int" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(short))
+                return "short" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(long))
+                return "long" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(double))
+                return "double" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(decimal))
+                return "decimal" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(float))
+                return "float" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(char))
+                return "char" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(bool))
+                return "bool" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(uint))
+                return "uint" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(ushort))
+                return "ushort" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(ulong))
+                return "ulong" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(byte))
+                return "byte" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(sbyte))
+                return "sbyte" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(DateTime))
+                return "DateTime" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(TimeSpan))
+                return "TimeSpan" + (column.AllowDBNull ? "?" : string.Empty);
+            else if (column.DataType == typeof(Type))
+                return "Type";
+            else if (column.DataType == typeof(byte[]))
+                return "byte[]";
+            else
+                return column.DataType.ToString() + (column.AllowDBNull && column.DataType.IsClass == false ? "?" : string.Empty);
+        }
+
+        #endregion
+
+        #region ValueToStringEventHandler
+
+        public delegate string ValueToStringEventHandler(object obj, DataRow row, DataColumn column);
+
+        #endregion
+
+        #region Print DataTable
+
+        public static void Print(this DataTable dataTable, params string[] columnNames)
+        {
+            Print(dataTable, false, 0, null, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, bool rowOrdinals, params string[] columnNames)
+        {
+            Print(dataTable, rowOrdinals, 0, null, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, int top, params string[] columnNames)
+        {
+            Print(dataTable, false, top, null, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            Print(dataTable, rowOrdinals, top, null, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataTable, false, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataTable, rowOrdinals, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataTable, false, top, toString, columnNames);
+        }
+
+        public static void Print(this DataTable dataTable, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, params string[] columnNames)
+        {
+            PrintRows(dataTable, dataTable.AsEnumerable(), rowOrdinals, top, toString, columnNames);
+        }
+
+        #endregion
+
+        #region Print DataView
+
+        public static void Print(this DataView dataView, params string[] columnNames)
+        {
+            Print(dataView, false, 0, null, columnNames);
+        }
+
+        public static void Print(this DataView dataView, bool rowOrdinals, params string[] columnNames)
+        {
+            Print(dataView, rowOrdinals, 0, null, columnNames);
+        }
+
+        public static void Print(this DataView dataView, int top, params string[] columnNames)
+        {
+            Print(dataView, false, top, null, columnNames);
+        }
+
+        public static void Print(this DataView dataView, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            Print(dataView, rowOrdinals, top, null, columnNames);
+        }
+
+        public static void Print(this DataView dataView, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataView, false, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataView dataView, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataView, rowOrdinals, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataView dataView, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataView, false, top, toString, columnNames);
+        }
+
+        public static void Print(this DataView dataView, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, params string[] columnNames)
+        {
+            PrintRows(dataView, rowOrdinals, top, toString, columnNames);
+        }
+
+        #endregion
+
+        #region Print DataSet
+
+        public static void Print(this DataSet dataSet, params string[] columnNames)
+        {
+            Print(dataSet, false, 0, null, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, bool rowOrdinals, params string[] columnNames)
+        {
+            Print(dataSet, rowOrdinals, 0, null, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, int top, params string[] columnNames)
+        {
+            Print(dataSet, false, top, null, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            Print(dataSet, rowOrdinals, top, null, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataSet, false, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataSet, rowOrdinals, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataSet, false, top, toString, columnNames);
+        }
+
+        public static void Print(this DataSet dataSet, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, params string[] columnNames)
+        {
+            foreach (DataTable dataTable in dataSet.Tables)
+                Print(dataTable, rowOrdinals, top, toString, columnNames);
+        }
+
+        #endregion
+
+        #region Print DataRow[]
+
+        public static void Print(this DataRow[] dataRows, params string[] columnNames)
+        {
+            Print(dataRows, false, 0, null, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, bool rowOrdinals, params string[] columnNames)
+        {
+            Print(dataRows, rowOrdinals, 0, null, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, int top, params string[] columnNames)
+        {
+            Print(dataRows, false, top, null, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            Print(dataRows, rowOrdinals, top, null, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataRows, false, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataRows, rowOrdinals, 0, toString, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            Print(dataRows, false, top, toString, columnNames);
+        }
+
+        public static void Print(this DataRow[] dataRows, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, params string[] columnNames)
+        {
+            PrintRows((dataRows.Length != 0 ? dataRows[0].Table : null), dataRows, rowOrdinals, top, toString, columnNames);
+        }
+
+        #endregion
+
+        #region Print Helper Methods
+
+        private static void PrintRows(DataTable dataTable, IEnumerable<DataRow> dataRows, bool rowOrdinals, int top, ValueToStringEventHandler toString, string[] columnNames, string ordinalColumnName = null)
+        {
+            if (dataTable == null && dataRows.Count() == 0)
+            {
+                WriteLine("No rows were selected");
+                WriteLine();
+                return;
+            }
+
+            if (dataTable != null && string.IsNullOrEmpty(dataTable.TableName) == false)
+                WriteLine("{0}:", dataTable.TableName);
+
+            DataColumn[] columns = GetColumns(dataTable, columnNames, ordinalColumnName);
+            if (columns.Length == 0)
+            {
+                WriteLine("No columns were selected");
+                WriteLine();
+                return;
+            }
+
+            if (top > 0)
+                dataRows = dataRows.Take(top);
+
+            int[] lengths = columns.Select(c => c.ColumnName.Length).ToArray();
+            foreach (DataRow row in dataRows)
+                CalculateLengths(row, columns, lengths, toString);
+
+            int rowOrdinalsLength = 0;
+            if (rowOrdinals)
+            {
+                if (dataRows.Count() > 0)
+                {
+                    int maxRowOrdinal = 0;
+                    if (string.IsNullOrEmpty(ordinalColumnName))
+                        maxRowOrdinal = dataRows.Select(row => row.Table.Rows.IndexOf(row)).Max();
+                    else
+                        maxRowOrdinal = dataRows.Select(row => (int)row[ordinalColumnName]).Max();
+
+                    if (maxRowOrdinal > -1)
+                        rowOrdinalsLength = maxRowOrdinal.ToString().Length;
+                }
+            }
+
+            string header = Top_Left.ToString();
+            string separator = Middle_Left.ToString();
+            string footer = Bottom_Left.ToString();
+            string formatHeaders = Verticl_Bar.ToString();
+            string format = Verticl_Bar.ToString();
+
+            if (rowOrdinals)
+            {
+                string horizontal = new String(Horizontal_Bar, rowOrdinalsLength + 2);
+                header += horizontal + Top_Center;
+                separator += horizontal + Middle_Center;
+                footer += horizontal + Bottom_Center;
+                formatHeaders += string.Format(" {{0,-{0}}} {1}", rowOrdinalsLength, Verticl_Bar);
+                format += string.Format(" {{0,{0}}} {1}", rowOrdinalsLength, Verticl_Bar);
+            }
+
+            int k = 0;
+            for (; k < columns.Length - 1; k++)
+            {
+                string horizontal = new String(Horizontal_Bar, lengths[k] + 2);
+                header += horizontal + Top_Center;
+                separator += horizontal + Middle_Center;
+                footer += horizontal + Bottom_Center;
+
+                string cellFormat = string.Format(" {{{0},-{1}}} {2}", k + 1, lengths[k], Verticl_Bar);
+                formatHeaders += cellFormat;
+                format += cellFormat;
+            }
+
+            k = columns.Length - 1;
+            if (k >= 0)
+            {
+                string horizontal = new String(Horizontal_Bar, lengths[k] + 2);
+                header += horizontal + Top_Right;
+                separator += horizontal + Middle_Right;
+                footer += horizontal + Bottom_Right;
+
+                string cellFormat = string.Format(" {{{0},-{1}}} {2}", k + 1, lengths[k], Verticl_Bar);
+                formatHeaders += cellFormat;
+                format += cellFormat;
+            }
+
+            object[] objects = new object[columns.Length + 1];
+
+            WriteLine(header);
+
+            objects[0] = string.Empty;
+            for (int i = 0; i < columns.Length; i++)
+                objects[i + 1] = columns[i];
+            WriteLine(formatHeaders, objects);
+
+            WriteLine(separator);
+
+            foreach (DataRow row in dataRows)
+            {
+                if (rowOrdinals)
+                {
+                    int ordinal = 0;
+                    if (string.IsNullOrEmpty(ordinalColumnName))
+                        ordinal = row.Table.Rows.IndexOf(row);
+                    else
+                        ordinal = (int)row[ordinalColumnName];
+                    objects[0] = (ordinal > -1 ? ordinal : (int?)null);
+                }
+
+                for (int i = 0; i < columns.Length; i++)
+                {
+                    object obj = row[columns[i]];
+
+                    string str = null;
+                    if (toString != null)
+                    {
+                        str = toString(obj, row, columns[i]);
+                        if (str == null)
+                            str = "null";
+                    }
+                    else
+                    {
+                        str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
+                    }
+
+                    objects[i + 1] = str;
+                }
+
+                WriteLine(format, objects);
+            }
+
+            WriteLine(footer);
+
+            WriteLine();
+        }
+
+        private static void PrintRows(DataView dataView, bool rowOrdinals, int top, ValueToStringEventHandler toString, string[] columnNames)
+        {
+            string ordinalColumnName = null;
+            DataTable dataTable = GetTableFromView(dataView, rowOrdinals, top, ref ordinalColumnName);
+            PrintRows(dataTable, dataTable.AsEnumerable(), rowOrdinals, top, toString, columnNames, ordinalColumnName);
+        }
+
+        private static DataTable GetTableFromView(DataView dataView, bool rowOrdinals, int top, ref string ordinalColumnName)
+        {
+            DataTable dataTable = dataView.ToTable();
+
+            if (rowOrdinals)
+            {
+                ordinalColumnName = "_ordinal";
+                while (dataTable.Columns.Contains(ordinalColumnName))
+                    ordinalColumnName = "_" + ordinalColumnName;
+                dataTable.Columns.Add(ordinalColumnName, typeof(int));
+
+                var it = dataView.GetEnumerator();
+                int rowCounter = -1;
+                while (it.MoveNext())
+                {
+                    rowCounter++;
+                    if (top > 0 && rowCounter >= top)
+                        break;
+                    DataRow dataRow = ((DataRowView)it.Current).Row;
+                    dataTable.Rows[rowCounter][ordinalColumnName] = dataRow.Table.Rows.IndexOf(dataRow);
+                }
+            }
+
+            return dataTable;
+        }
+
+        private static DataColumn[] GetColumns(DataTable dataTable, string[] columnNames, string ordinalColumnName = null)
+        {
+            if (columnNames != null && columnNames.Length > 0)
+                return columnNames.Join(dataTable.Columns.Cast<DataColumn>(), n => n, c => c.ColumnName, (n, c) => c, StringComparer.CurrentCultureIgnoreCase).Where(c => string.IsNullOrEmpty(ordinalColumnName) || c.ColumnName != ordinalColumnName).ToArray();
+            else
+                return dataTable.Columns.Cast<DataColumn>().Where(c => string.IsNullOrEmpty(ordinalColumnName) || c.ColumnName != ordinalColumnName).ToArray();
+        }
+
+        private static void CalculateLengths(DataRow row, DataColumn[] columns, int[] lengths, ValueToStringEventHandler toString)
+        {
+            for (int i = 0; i < columns.Length; i++)
+            {
+                object obj = row[columns[i]];
+
+                string str;
+                if (toString != null)
+                {
+                    str = toString(obj, row, columns[i]);
+                    if (str == null)
+                        str = "null";
+                }
+                else
+                {
+                    str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
+                }
+
+                if (lengths[i] < str.Length)
+                    lengths[i] = str.Length;
+            }
+        }
+
+        #endregion
+
+        #region RepeatDirection
+
+        public enum RepeatDirection
+        {
+            Horizontal = 0,
+            Vertical = 1,
+        }
+
+        #endregion
+
+        #region PrintList DataTable
+
+        public static void PrintList(this DataTable dataTable, params string[] columnNames)
+        {
+            PrintList(dataTable, false, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, bool rowOrdinals, params string[] columnNames)
+        {
+            PrintList(dataTable, rowOrdinals, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, int top, params string[] columnNames)
+        {
+            PrintList(dataTable, false, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            PrintList(dataTable, rowOrdinals, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataTable, false, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataTable, rowOrdinals, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataTable, false, top, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, int repeatColumns, RepeatDirection repeatDirection, params string[] columnNames)
+        {
+            PrintList(dataTable, false, 0, null, repeatColumns: repeatColumns, repeatDirection: repeatDirection, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataTable dataTable, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, int repeatColumns = 2, RepeatDirection repeatDirection = RepeatDirection.Vertical, string delimiter = ": ", params string[] columnNames)
+        {
+            PrintListRows(dataTable, dataTable.AsEnumerable(), rowOrdinals, top, toString, repeatColumns, repeatDirection, delimiter, columnNames);
+        }
+
+        #endregion
+
+        #region PrintList DataView
+
+        public static void PrintList(this DataView dataView, params string[] columnNames)
+        {
+            PrintList(dataView, false, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, bool rowOrdinals, params string[] columnNames)
+        {
+            PrintList(dataView, rowOrdinals, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, int top, params string[] columnNames)
+        {
+            PrintList(dataView, false, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            PrintList(dataView, rowOrdinals, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataView, false, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataView, rowOrdinals, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataView, false, top, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, int repeatColumns, RepeatDirection repeatDirection, params string[] columnNames)
+        {
+            PrintList(dataView, false, 0, null, repeatColumns: repeatColumns, repeatDirection: repeatDirection, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataView dataView, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, int repeatColumns = 2, RepeatDirection repeatDirection = RepeatDirection.Vertical, string delimiter = ": ", params string[] columnNames)
+        {
+            PrintListRows(dataView, rowOrdinals, top, toString, repeatColumns, repeatDirection, delimiter, columnNames);
+        }
+
+        #endregion
+
+        #region PrintList DataSet
+
+        public static void PrintList(this DataSet dataSet, params string[] columnNames)
+        {
+            PrintList(dataSet, false, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, bool rowOrdinals, params string[] columnNames)
+        {
+            PrintList(dataSet, rowOrdinals, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, int top, params string[] columnNames)
+        {
+            PrintList(dataSet, false, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            PrintList(dataSet, rowOrdinals, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataSet, false, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataSet, rowOrdinals, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataSet, false, top, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, int repeatColumns, RepeatDirection repeatDirection, params string[] columnNames)
+        {
+            PrintList(dataSet, false, 0, null, repeatColumns: repeatColumns, repeatDirection: repeatDirection, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataSet dataSet, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, int repeatColumns = 2, RepeatDirection repeatDirection = RepeatDirection.Vertical, string delimiter = ": ", params string[] columnNames)
+        {
+            foreach (DataTable dataTable in dataSet.Tables)
+                PrintList(dataTable, rowOrdinals, top, toString, repeatColumns, repeatDirection, delimiter, columnNames);
+        }
+
+        #endregion
+
+        #region PrintList DataRow[]
+
+        public static void PrintList(this DataRow[] dataRows, params string[] columnNames)
+        {
+            PrintList(dataRows, false, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, bool rowOrdinals, params string[] columnNames)
+        {
+            PrintList(dataRows, rowOrdinals, 0, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, int top, params string[] columnNames)
+        {
+            PrintList(dataRows, false, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, bool rowOrdinals, int top, params string[] columnNames)
+        {
+            PrintList(dataRows, rowOrdinals, top, null, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataRows, false, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, bool rowOrdinals, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataRows, rowOrdinals, 0, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, int top, ValueToStringEventHandler toString, params string[] columnNames)
+        {
+            PrintList(dataRows, false, top, toString, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, int repeatColumns, RepeatDirection repeatDirection, params string[] columnNames)
+        {
+            PrintList(dataRows, false, 0, null, repeatColumns: repeatColumns, repeatDirection: repeatDirection, columnNames: columnNames);
+        }
+
+        public static void PrintList(this DataRow[] dataRows, bool rowOrdinals = false, int top = 0, ValueToStringEventHandler toString = null, int repeatColumns = 2, RepeatDirection repeatDirection = RepeatDirection.Vertical, string delimiter = ": ", params string[] columnNames)
+        {
+            PrintListRows((dataRows.Length != 0 ? dataRows[0].Table : null), dataRows, rowOrdinals, top, toString, repeatColumns, repeatDirection, delimiter, columnNames);
+        }
+
+        #endregion
+
+        #region PrintList Helper Methods
+
+        private static void PrintListRows(DataTable dataTable, IEnumerable<DataRow> dataRows, bool rowOrdinals, int top, ValueToStringEventHandler toString, int repeatColumns, RepeatDirection repeatDirection, string delimiter, string[] columnNames, string ordinalColumnName = null)
+        {
+            if (dataTable != null && string.IsNullOrEmpty(dataTable.TableName) == false)
+                WriteLine("{0}:", dataTable.TableName);
+
+            if (dataRows.Count() == 0)
+            {
+                WriteLine("No rows were selected");
+                WriteLine();
+                return;
+            }
+
+            DataColumn[] columns = GetColumns(dataTable, columnNames, ordinalColumnName);
+            if (columns.Length == 0)
+            {
+                WriteLine("No columns were selected");
+                WriteLine();
+                return;
+            }
+
+            if (top > 0)
+                dataRows = dataRows.Take(top);
+
+            int columnsLength = columns.Select(c => c.ColumnName.Length).Max();
+
+            int[] lengths = new int[columns.Length];
+            foreach (DataRow row in dataRows)
+                CalculateLengths(row, columns, lengths, toString);
+            int rowsLength = lengths.Max();
+
+            if (rowOrdinals)
+            {
+                if (dataRows.Count() > 0)
+                {
+                    if (columnsLength < 7) // "Ordinal".Length
+                        columnsLength = 7;
+
+                    int maxRowOrdinal = 0;
+                    if (string.IsNullOrEmpty(ordinalColumnName))
+                        maxRowOrdinal = dataRows.Select(row => row.Table.Rows.IndexOf(row)).Max();
+                    else
+                        maxRowOrdinal = dataRows.Select(row => (int)row[ordinalColumnName]).Max();
+
+                    if (maxRowOrdinal > -1)
+                    {
+                        int rowOrdinalsLength = maxRowOrdinal.ToString().Length;
+                        if (rowsLength < rowOrdinalsLength)
+                            rowsLength = rowOrdinalsLength;
+                    }
+                }
+            }
+
+            if (repeatColumns < 1)
+                repeatColumns = 1;
+
+            if (repeatColumns > dataRows.Count())
+                repeatColumns = dataRows.Count();
+
+            int lastRowFilledCellsCount = dataRows.Count() % repeatColumns;
+            if (lastRowFilledCellsCount == 0)
+                lastRowFilledCellsCount = repeatColumns;
+            int lastRowEmptyCellsCount = repeatColumns - lastRowFilledCellsCount;
+            int rowsCount = (dataRows.Count() / repeatColumns) + (dataRows.Count() % repeatColumns > 0 ? 1 : 0);
+
+            if (delimiter == null)
+                delimiter = string.Empty;
+
+            string cellFormat = string.Format(" {{{{0,-{0}}}}}{1}{{{{{{0}},-{2}}}}} {3}", columnsLength, delimiter, rowsLength, Verticl_Bar);
+            string horizontal = new String(Horizontal_Bar, columnsLength + delimiter.Length + rowsLength + 2);
+
+            string header = Top_Left.ToString();
+            string separator = Middle_Left.ToString();
+            string footer = Bottom_Left.ToString();
+            string format = Verticl_Bar.ToString();
+
+            int k = 0;
+            for (; k < repeatColumns - 1; k++)
+            {
+                header += horizontal + Top_Center;
+                separator += horizontal + Middle_Center;
+                footer += horizontal + Bottom_Center;
+                format += string.Format(cellFormat, k + 1);
+            }
+
+            k = repeatColumns - 1;
+            if (k >= 0)
+            {
+                header += horizontal + Top_Right;
+                separator += horizontal + Middle_Right;
+                footer += horizontal + Bottom_Right;
+                format += string.Format(cellFormat, k + 1);
+            }
+
+            string formatPartial = format;
+            if (lastRowEmptyCellsCount > 0)
+            {
+                formatPartial = Verticl_Bar.ToString();
+                for (int i = 0; i < lastRowFilledCellsCount; i++)
+                    formatPartial += string.Format(cellFormat, i + 1);
+                for (int i = 0; i < lastRowEmptyCellsCount; i++)
+                    formatPartial += new String(' ', columnsLength + delimiter.Length + rowsLength + 2) + Verticl_Bar;
+            }
+
+            object[] objects = new object[repeatColumns + 1];
+
+            if (repeatDirection == RepeatDirection.Horizontal)
+            {
+                for (int i = 0; i < rowsCount; i++)
+                {
+                    WriteLine(i == 0 ? header : separator);
+                    var rows = dataRows.Skip(i * repeatColumns).Take(repeatColumns);
+                    PrintListRow(rows, columns, objects, (i < rowsCount - 1 ? format : formatPartial), rowOrdinals, toString, ordinalColumnName);
+                }
+            }
+            else if (repeatDirection == RepeatDirection.Vertical && lastRowEmptyCellsCount == 0)
+            {
+                for (int i = 0; i < rowsCount; i++)
+                {
+                    WriteLine(i == 0 ? header : separator);
+                    var rows = dataRows.Where((r, n) => n % rowsCount == i);
+                    PrintListRow(rows, columns, objects, (i < rowsCount - 1 ? format : formatPartial), rowOrdinals, toString, ordinalColumnName);
+                }
+            }
+            else if (repeatDirection == RepeatDirection.Vertical && lastRowEmptyCellsCount > 0)
+            {
+                for (int i = 0; i < rowsCount; i++)
+                {
+                    WriteLine(i == 0 ? header : separator);
+                    var rows = dataRows.Where((r, n) =>
+                        (n < lastRowFilledCellsCount * rowsCount && n % rowsCount == i) ||
+                        (n >= lastRowFilledCellsCount * rowsCount && (n - (lastRowFilledCellsCount * rowsCount)) % (rowsCount - 1) == i)
+                    );
+                    PrintListRow(rows, columns, objects, (i < rowsCount - 1 ? format : formatPartial), rowOrdinals, toString, ordinalColumnName);
+                }
+            }
+
+            WriteLine(footer);
+
+            WriteLine();
+        }
+
+        private static void PrintListRows(DataView dataView, bool rowOrdinals, int top, ValueToStringEventHandler toString, int repeatColumns, RepeatDirection repeatDirection, string delimiter, string[] columnNames)
+        {
+            string ordinalColumnName = null;
+            DataTable dataTable = GetTableFromView(dataView, rowOrdinals, top, ref ordinalColumnName);
+            PrintListRows(dataTable, dataTable.AsEnumerable(), rowOrdinals, top, toString, repeatColumns, repeatDirection, delimiter, columnNames, ordinalColumnName);
+        }
+
+        private static void PrintListRow(IEnumerable<DataRow> rows, DataColumn[] columns, object[] objects, string format, bool rowOrdinals, ValueToStringEventHandler toString, string ordinalColumnName)
+        {
+            if (rowOrdinals)
+            {
+                IEnumerable<int> ordinals = null;
+                if (string.IsNullOrEmpty(ordinalColumnName))
+                    ordinals = rows.Select(row => row.Table.Rows.IndexOf(row));
+                else
+                    ordinals = rows.Select(row => (int)row[ordinalColumnName]);
+
+                objects[0] = "Ordinal";
+                int k = 1;
+                foreach (int ordinal in ordinals)
+                    objects[k++] = (ordinal > -1 ? ordinal : (int?)null);
+                WriteLine(format, objects);
+            }
+
+            for (int i = 0; i < columns.Length; i++)
+            {
+                objects[0] = columns[i].ColumnName;
+
+                int k = 1;
+                foreach (DataRow row in rows)
+                {
+                    object obj = row[columns[i]];
+
+                    string str = null;
+                    if (toString != null)
+                    {
+                        str = toString(obj, row, columns[i]);
+                        if (str == null)
+                            str = "null";
+                    }
+                    else
+                    {
+                        str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
+                    }
+
+                    objects[k++] = str;
+                }
+
+                WriteLine(format, objects);
+            }
+        }
+
+        #endregion
+
+        #region Write, WriteLine Event Handlers
+
+        public delegate void WriteEventHandler(string value = null, params object[] args);
+        public delegate void WriteLineEventHandler(string value = null, params object[] args);
+
+        #endregion
+
+        #region Set Output
+
+        private static event WriteEventHandler Write = ConsoleWriteEventHandler;
+        private static event WriteLineEventHandler WriteLine = ConsoleWriteLineEventHandler;
+
+        public static void SetOutput(WriteEventHandler writeEventHandler, WriteLineEventHandler writeLineEventHandler)
+        {
+            Write = null;
+            Write += writeEventHandler;
+
+            WriteLine = null;
+            WriteLine += writeLineEventHandler;
+        }
+
+        public static void SetOutputConsole()
+        {
+            SetOutput(ConsoleWriteEventHandler, ConsoleWriteLineEventHandler);
+        }
+
+        public static void SetOutputStringBuilder(StringBuilder builder)
+        {
+            SetOutput(
+                (value, args) => StringBuilderWriteEventHandler(builder, value, args),
+                (value, args) => StringBuilderWriteLineEventHandler(builder, value, args)
+            );
+        }
+
+        public static void SetOutputStream(Stream stream)
+        {
+            SetOutputStream(stream, Encoding.UTF8);
+        }
+
+        public static void SetOutputStream(Stream stream, Encoding encoding)
+        {
+            SetOutput(
+                (value, args) => StreamWriteEventHandler(stream, encoding ?? Encoding.UTF8, value, args),
+                (value, args) => StreamWriteLineEventHandler(stream, encoding ?? Encoding.UTF8, value, args)
+            );
+        }
+
+        #endregion
+
+        #region Console Event Handlers
+
+        private static void ConsoleWriteEventHandler(string value = null, params object[] args)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            if (args == null)
+                Console.Write(value);
+            else
+                Console.Write(value, args);
+        }
+
+        private static void ConsoleWriteLineEventHandler(string value = null, params object[] args)
+        {
+            if (string.IsNullOrEmpty(value))
+                Console.WriteLine();
+            else if (args == null)
+                Console.WriteLine(value);
+            else
+                Console.WriteLine(value, args);
+        }
+
+        #endregion
+
+        #region StringBuilder Event Handlers
+
+        private static void StringBuilderWriteEventHandler(StringBuilder builder, string value = null, params object[] args)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            if (args == null)
+                builder.Append(value);
+            else
+                builder.AppendFormat(value, args);
+        }
+
+        private static void StringBuilderWriteLineEventHandler(StringBuilder builder, string value = null, params object[] args)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                builder.AppendLine();
+            }
+            else if (args == null)
+            {
+                builder.AppendLine(value);
+            }
+            else
+            {
+                builder.AppendFormat(value, args);
+                builder.AppendLine();
+            }
+        }
+
+        #endregion
+
+        #region Stream Event Handlers
+
+        private static void StreamWriteEventHandler(Stream stream, Encoding encoding, string value = null, params object[] args)
+        {
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            byte[] buffer;
+            if (args == null)
+                buffer = encoding.GetBytes(value);
+            else
+                buffer = encoding.GetBytes(string.Format(value, args));
+
+            stream.Write(buffer, 0, buffer.Length);
+        }
+
+        private static void StreamWriteLineEventHandler(Stream stream, Encoding encoding, string value = null, params object[] args)
+        {
+            byte[] buffer;
+            if (string.IsNullOrEmpty(value) == false)
+            {
+                if (args == null)
+                    buffer = encoding.GetBytes(value);
+                else
+                    buffer = encoding.GetBytes(string.Format(value, args));
+                stream.Write(buffer, 0, buffer.Length);
+            }
+
+            buffer = encoding.GetBytes(Environment.NewLine);
+            stream.Write(buffer, 0, buffer.Length);
+        }
+
+        #endregion
+
+        #region Border
+
+        private const char ASCII_MINUS = '-';
+        private const char ASCII_VERTICL_BAR = '|';
+        private const char ASCII_PLUS = '+';
+        private const char EXTENDED_ASCII_HORIZONTAL_BAR = '─';
+        private const char EXTENDED_ASCII_VERTICL_BAR = '│';
+        private const char EXTENDED_ASCII_TOP_LEFT = '┌';
+        private const char EXTENDED_ASCII_TOP_CENTER = '┬';
+        private const char EXTENDED_ASCII_TOP_RIGHT = '┐';
+        private const char EXTENDED_ASCII_MIDDLE_LEFT = '├';
+        private const char EXTENDED_ASCII_MIDDLE_CENTER = '┼';
+        private const char EXTENDED_ASCII_MIDDLE_RIGHT = '┤';
+        private const char EXTENDED_ASCII_BOTTOM_LEFT = '└';
+        private const char EXTENDED_ASCII_BOTTOM_CENTER = '┴';
+        private const char EXTENDED_ASCII_BOTTOM_RIGHT = '┘';
+
+        private static char Horizontal_Bar;
+        private static char Verticl_Bar;
+        private static char Top_Left;
+        private static char Top_Center;
+        private static char Top_Right;
+        private static char Middle_Left;
+        private static char Middle_Center;
+        private static char Middle_Right;
+        private static char Bottom_Left;
+        private static char Bottom_Center;
+        private static char Bottom_Right;
+
+        public static void ClearBorder()
+        {
+            Horizontal_Bar = ' ';
+            Verticl_Bar = ' ';
+            Top_Left = ' ';
+            Top_Center = ' ';
+            Top_Right = ' ';
+            Middle_Left = ' ';
+            Middle_Center = ' ';
+            Middle_Right = ' ';
+            Bottom_Left = ' ';
+            Bottom_Center = ' ';
+            Bottom_Right = ' ';
+        }
+
+        public static void ASCIIBorder()
+        {
+            Horizontal_Bar = ASCII_MINUS;
+            Verticl_Bar = ASCII_VERTICL_BAR;
+            Top_Left = ASCII_PLUS;
+            Top_Center = ASCII_PLUS;
+            Top_Right = ASCII_PLUS;
+            Middle_Left = ASCII_PLUS;
+            Middle_Center = ASCII_PLUS;
+            Middle_Right = ASCII_PLUS;
+            Bottom_Left = ASCII_PLUS;
+            Bottom_Center = ASCII_PLUS;
+            Bottom_Right = ASCII_PLUS;
+        }
+
+        public static void ExtendedASCIIBorder()
+        {
+            Horizontal_Bar = EXTENDED_ASCII_HORIZONTAL_BAR;
+            Verticl_Bar = EXTENDED_ASCII_VERTICL_BAR;
+            Top_Left = EXTENDED_ASCII_TOP_LEFT;
+            Top_Center = EXTENDED_ASCII_TOP_CENTER;
+            Top_Right = EXTENDED_ASCII_TOP_RIGHT;
+            Middle_Left = EXTENDED_ASCII_MIDDLE_LEFT;
+            Middle_Center = EXTENDED_ASCII_MIDDLE_CENTER;
+            Middle_Right = EXTENDED_ASCII_MIDDLE_RIGHT;
+            Bottom_Left = EXTENDED_ASCII_BOTTOM_LEFT;
+            Bottom_Center = EXTENDED_ASCII_BOTTOM_CENTER;
+            Bottom_Right = EXTENDED_ASCII_BOTTOM_RIGHT;
+        }
+
+        static PrintDataExtensions()
+        {
+            ExtendedASCIIBorder();
+        }
+
+        #endregion
+    }
+}

--- a/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
+++ b/ricaun.AppBundleTool/Utils/PrintDataExtensions.cs
@@ -1,15 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace System.Data
+namespace ricaun.AppBundleTool.Utils
 {
     /// <summary>
+    /// PrintDataExtensions with basic Console color support
+    /// </summary>
+    /// <remarks>
+    /// Based:
     /// https://github.com/yuvalsol/PrintDataTableToConsole
     /// https://github.com/yuvalsol/PrintDataTableToConsole/blob/master/PrintData/PrintDataExtensions.cs
-    /// </summary>
+    /// </remarks>
     internal static partial class PrintDataExtensions
     {
         #region Print Columns
@@ -30,6 +35,11 @@ namespace System.Data
                 PrintColumns(dataTable, columnNames);
         }
 
+        private static int GetLength(this string value)
+        {
+            return value.ToConsoleLength();
+        }
+
         private static void PrintColumns(string name, DataColumn[] columns)
         {
             string columnName = "Column Name";
@@ -38,26 +48,26 @@ namespace System.Data
             string dataMember = "Data Member";
 
             int length0 = 0;
-            int length1 = columnName.Length;
-            int length2 = dataType.Length;
-            int length3 = nullable.Length;
-            int length4 = dataMember.Length;
+            int length1 = columnName.GetLength();
+            int length2 = dataType.GetLength();
+            int length3 = nullable.GetLength();
+            int length4 = dataMember.GetLength();
 
             if (columns.Length > 0)
             {
-                int maxLength = columns.Select(c => c.Ordinal).Max().ToString().Length;
+                int maxLength = columns.Select(c => c.Ordinal).Max().ToString().GetLength();
                 if (length0 < maxLength)
                     length0 = maxLength;
 
-                maxLength = columns.Select(c => c.ColumnName.Length).Max();
+                maxLength = columns.Select(c => c.ColumnName.GetLength()).Max();
                 if (length1 < maxLength)
                     length1 = maxLength;
 
-                maxLength = columns.Select(c => c.DataType.ToString().Length).Max();
+                maxLength = columns.Select(c => c.DataType.ToString().GetLength()).Max();
                 if (length2 < maxLength)
                     length2 = maxLength;
 
-                maxLength = columns.Select(c => GetDataMemberType(c).Length + 1 + c.ColumnName.Length).Max();
+                maxLength = columns.Select(c => GetDataMemberType(c).GetLength() + 1 + c.ColumnName.GetLength()).Max();
                 if (length4 < maxLength)
                     length4 = maxLength;
             }
@@ -81,7 +91,7 @@ namespace System.Data
             foreach (DataColumn column in columns)
             {
                 string dataMemberType = GetDataMemberType(column);
-                string format2 = string.Format("{{5}} {{0,{0}}} {{5}} {{1,-{1}}} {{5}} {{2,-{2}}} {{5}} {{3,-{3}}} {{5}} {{4}} {{1}} {{5,{4}}}", length0, length1, length2, length3, length4 - dataMemberType.Length - column.ColumnName.Length);
+                string format2 = string.Format("{{5}} {{0,{0}}} {{5}} {{1,-{1}}} {{5}} {{2,-{2}}} {{5}} {{3,-{3}}} {{5}} {{4}} {{1}} {{5,{4}}}", length0, length1, length2, length3, length4 - dataMemberType.GetLength() - column.ColumnName.GetLength());
                 WriteLine(format2, column.Ordinal, column.ColumnName, column.DataType, column.AllowDBNull, dataMemberType, Verticl_Bar);
             }
 
@@ -342,7 +352,7 @@ namespace System.Data
             if (top > 0)
                 dataRows = dataRows.Take(top);
 
-            int[] lengths = columns.Select(c => c.ColumnName.Length).ToArray();
+            int[] lengths = columns.Select(c => c.ColumnName.GetLength()).ToArray();
             foreach (DataRow row in dataRows)
                 CalculateLengths(row, columns, lengths, toString);
 
@@ -358,7 +368,7 @@ namespace System.Data
                         maxRowOrdinal = dataRows.Select(row => (int)row[ordinalColumnName]).Max();
 
                     if (maxRowOrdinal > -1)
-                        rowOrdinalsLength = maxRowOrdinal.ToString().Length;
+                        rowOrdinalsLength = maxRowOrdinal.ToString().GetLength();
                 }
             }
 
@@ -441,6 +451,12 @@ namespace System.Data
                     else
                     {
                         str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
+                        if (str.Length != str.GetLength())
+                        {
+                            var extraSpaces = lengths[i] - str.GetLength();
+                            if (extraSpaces > 0)
+                                str += new string(' ', extraSpaces); // Ensure the string is padded to the correct length
+                        }
                     }
 
                     objects[i + 1] = str;
@@ -513,8 +529,8 @@ namespace System.Data
                     str = string.Format("{0}", (obj == DBNull.Value || obj == null ? "null" : obj));
                 }
 
-                if (lengths[i] < str.Length)
-                    lengths[i] = str.Length;
+                if (lengths[i] < str.GetLength())
+                    lengths[i] = str.GetLength();
             }
         }
 
@@ -752,7 +768,7 @@ namespace System.Data
             if (top > 0)
                 dataRows = dataRows.Take(top);
 
-            int columnsLength = columns.Select(c => c.ColumnName.Length).Max();
+            int columnsLength = columns.Select(c => c.ColumnName.GetLength()).Max();
 
             int[] lengths = new int[columns.Length];
             foreach (DataRow row in dataRows)
@@ -774,7 +790,7 @@ namespace System.Data
 
                     if (maxRowOrdinal > -1)
                     {
-                        int rowOrdinalsLength = maxRowOrdinal.ToString().Length;
+                        int rowOrdinalsLength = maxRowOrdinal.ToString().GetLength();
                         if (rowsLength < rowOrdinalsLength)
                             rowsLength = rowOrdinalsLength;
                     }

--- a/ricaun.AppBundleTool/Utils/RecycleBinUtils.cs
+++ b/ricaun.AppBundleTool/Utils/RecycleBinUtils.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.VisualBasic.FileIO;
+using System.IO;
+
+namespace ricaun.AppBundleTool.Utils
+{
+    /// <summary>
+    /// Provides utility methods for sending files and directories to the Recycle Bin.
+    /// </summary>
+    public static class RecycleBinUtils
+    {
+        /// <summary>
+        /// Sends the specified file to the Recycle Bin if it exists.
+        /// </summary>
+        /// <param name="path">The full path of the file to recycle.</param>
+        /// <returns>
+        /// <c>true</c> if the file existed and was sent to the Recycle Bin; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool FileToRecycleBin(string path)
+        {
+            if (File.Exists(path))
+            {
+                FileSystem.DeleteFile(path,
+                    UIOption.OnlyErrorDialogs,
+                    RecycleOption.SendToRecycleBin);
+
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Sends the specified directory to the Recycle Bin if it exists.
+        /// </summary>
+        /// <param name="path">The full path of the directory to recycle.</param>
+        /// <returns>
+        /// <c>true</c> if the directory existed and was sent to the Recycle Bin; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool DirectoryToRecycleBin(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                FileSystem.DeleteDirectory(path,
+                    UIOption.OnlyErrorDialogs,
+                    RecycleOption.SendToRecycleBin);
+
+                return true;
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Features
- Support `Autodesk` native bundle with admin privileges.
- Show list of bundles in table format using `DataTable`.
- Support to find app by `BundleName` or `AppName`.
- Show `AppBundle` information in table format.
- Support Console color output in table format in `Admin` as red color.
- Support `ProgramFilesX86` folder for `AutoCAD` bundles.
### Updates
- Add `AppBundleAccess` to show bundle access information (`Allow` or `Admin`)
- Update uninstall to use `UninstallAppBundle` with `RecycleBinUtils`.
- Add `RecycleBinUtils` with methods to recycle files and folders.
- Add `AppNameSpace` and `AppUpgradeCode` in the `ApplicationPackage` class.
### Fixes
- Fix `PackageContents.xml` requires admin privileges to read. (Fix: #1)