### PR TITLE
Version 1.0.5

### DIFF
--- a/Build/.nuke/build.schema.json
+++ b/Build/.nuke/build.schema.json
@@ -32,7 +32,8 @@
         "Pack",
         "PrePack",
         "Release",
-        "Sign"
+        "Sign",
+        "Test"
       ]
     },
     "Verbosity": {
@@ -150,6 +151,15 @@
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
+        },
+        "TestBuildStopWhenFailed": {
+          "type": "boolean"
+        },
+        "TestProjectName": {
+          "type": "string"
+        },
+        "TestResults": {
+          "type": "boolean"
         },
         "UnlistNuGet": {
           "type": "boolean"

--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -3,7 +3,7 @@ using Nuke.Common.Execution;
 using ricaun.Nuke;
 using ricaun.Nuke.Components;
 
-class Build : NukeBuild, IPublishPack, IPrePack
+class Build : NukeBuild, IPublishPack, IPrePack, ITest
 {
     public static int Main() => Execute<Build>(x => x.From<IPublishPack>().Build);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] / 2025-11-03
+### Features
+- Support install `{name}.{version}.bundle.zip` format and remove `{version}` when install bundle.
+### Updates
+- Add `NameAndVersionBundleUtils` to parse bundle name and version from file name.
+### Tests
+- Add unit tests for `NameAndVersionBundleUtils`.
+
 ## [1.0.4] / 2025-09-19
 ### Features
 - Add percentage in the progress bar.
@@ -53,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `DownloadUtils` to support local file.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.5]: ../../compare/1.0.4...1.0.5
 [1.0.4]: ../../compare/1.0.3...1.0.4
 [1.0.3]: ../../compare/1.0.2...1.0.3
 [1.0.2]: ../../compare/1.0.1...1.0.2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.5-beta</Version>
+    <Version>1.0.5-rc</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.5-rc</Version>
+    <Version>1.0.5</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.4</Version>
+    <Version>1.0.5-beta</Version>
   </PropertyGroup>
 </Project>

--- a/ricaun.AppBundleTool.Tests/NameAndVersionTests.cs
+++ b/ricaun.AppBundleTool.Tests/NameAndVersionTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using ricaun.AppBundleTool.Utils;
+
+namespace ricaun.AppBundleTool.Tests
+{
+    public class NameAndVersionTests
+    {
+        [TestCase("MyLib.1.2.3.bundle", "MyLib", "1.2.3")]
+        [TestCase("Plugin.3.4.5-beta.bundle", "Plugin", "3.4.5-beta")]
+        [TestCase("My.Lib.Core.2.0.0.bundle", "My.Lib.Core", "2.0.0")]
+        [TestCase("ToolName.10.0.1-alpha.bundle", "ToolName", "10.0.1-alpha")]
+        [TestCase("Library.1.0.0.1.bundle", "Library", "1.0.0.1")] // supports 4 numeric parts
+        public void TryGetNameAndVersionBundle_ValidNames_ShouldReturnTrue(string fileName, string expectedName, string expectedVersion)
+        {
+            // Act
+            var result = NameAndVersionBundleUtils.TryGetNameAndVersionBundle(fileName, out var name, out var version);
+
+            // Assert
+            Assert.IsTrue(result, $"Expected success for '{fileName}'");
+            Assert.AreEqual(expectedName, name);
+            Assert.AreEqual(expectedVersion, version);
+        }
+
+        [TestCase("InvalidFile.bundle")]
+        [TestCase("AnotherFile.txt")]
+        [TestCase("Package.1.2.bundle")] // only 2 numeric parts
+        [TestCase("Package.1.2.3.bundle.zip")] // not ending with .bundle
+        [TestCase("Package.1.2.3")] // missing .bundle
+        [TestCase("Package1.2.3.bundle")] // missing dot before version
+        public void TryGetNameAndVersionBundle_InvalidNames_ShouldReturnFalse(string fileName)
+        {
+            // Act
+            var result = NameAndVersionBundleUtils.TryGetNameAndVersionBundle(fileName, out var name, out var version);
+
+            // Assert
+            Assert.IsFalse(result, $"Expected failure for '{fileName}'");
+            Assert.IsNull(name);
+            Assert.IsNull(version);
+        }
+    }
+}

--- a/ricaun.AppBundleTool.Tests/ricaun.AppBundleTool.Tests.csproj
+++ b/ricaun.AppBundleTool.Tests/ricaun.AppBundleTool.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ricaun.AppBundleTool\ricaun.AppBundleTool.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ricaun.AppBundleTool.sln
+++ b/ricaun.AppBundleTool.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35728.132 d17.12
+VisualStudioVersion = 17.12.35728.132
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{A5D13B37-DD47-442A-AB51-EED6B3832B26}"
 	ProjectSection(SolutionItems) = preProject
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ricaun.AppBundleTool", "ric
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Build", "Build\Build.csproj", "{A3745FFF-BAF2-4372-B296-69189D272969}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ricaun.AppBundleTool.Tests", "ricaun.AppBundleTool.Tests\ricaun.AppBundleTool.Tests.csproj", "{E523F919-DCD6-4C88-BC17-FB5C97A860EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{FB8D90B7-1370-4E50-91EE-0B0FB45B373E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A3745FFF-BAF2-4372-B296-69189D272969}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A3745FFF-BAF2-4372-B296-69189D272969}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E523F919-DCD6-4C88-BC17-FB5C97A860EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E523F919-DCD6-4C88-BC17-FB5C97A860EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E523F919-DCD6-4C88-BC17-FB5C97A860EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E523F919-DCD6-4C88-BC17-FB5C97A860EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -190,8 +190,12 @@ namespace ricaun.AppBundleTool
             };
             var bundlePathZip = DownloadUtils.DownloadAsync(bundleUrl).ConsoleWaitResult(downloadProgress, () => { return processPercentage; });
 
+            var bundlePathFolderName = Path.GetFileNameWithoutExtension(bundlePathZip);
+            if (NameAndVersionBundleUtils.TryGetNameAndVersionBundle(bundlePathFolderName, out string name, out string _))
+                bundlePathFolderName = name + Path.GetExtension(bundlePathFolderName);
+
             // unzip file to folder
-            var bundlePathFolder = Path.Combine(Path.GetDirectoryName(bundlePathZip), Path.GetFileNameWithoutExtension(bundlePathZip));
+            var bundlePathFolder = Path.Combine(Path.GetDirectoryName(bundlePathZip), bundlePathFolderName);
             if (Directory.Exists(bundlePathFolder))
                 Directory.Delete(bundlePathFolder, true);
 

--- a/ricaun.AppBundleTool/Utils/NameAndVersionBundleUtils.cs
+++ b/ricaun.AppBundleTool/Utils/NameAndVersionBundleUtils.cs
@@ -1,0 +1,52 @@
+namespace ricaun.AppBundleTool.Utils;
+
+/// <summary>
+/// Provides utility methods for extracting name and semantic version information from file names.
+/// </summary>
+public static class NameAndVersionBundleUtils
+{
+    /// <summary>
+    /// The regular expression pattern used to match file names with a specific format.
+    /// </summary>
+    /// <remarks>
+    /// The pattern expects file names in the format: <c>{name}.{semanticVersion}.bundle</c>.
+    /// - <c>{name}</c>: Represents the name of the file.
+    /// - <c>{semanticVersion}</c>: Represents the semantic version, which includes at least three numeric segments and may include additional alphanumeric identifiers.
+    /// </remarks>
+    const string pattern = @"^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z0-9]+?\.?)*)\.bundle$";
+
+    /// <summary>
+    /// Attempts to extract the name and semantic version from a given file name.
+    /// </summary>
+    /// <param name="fileName">The file name to parse.</param>
+    /// <param name="name">The extracted name, if the operation is successful; otherwise, <c>null</c>.</param>
+    /// <param name="semanticVersion">The extracted semantic version, if the operation is successful; otherwise, <c>null</c>.</param>
+    /// <returns>
+    /// <c>true</c> if the name and semantic version were successfully extracted; otherwise, <c>false</c>.
+    /// </returns>
+    /// <example>
+    /// Example usage:
+    /// <code>
+    /// string fileName = "MyApp.1.0.0-alpha.bundle";
+    /// if (NameAndVersionBundleUtils.TryGetNameAndVersionBundle(fileName, out string name, out string version))
+    /// {
+    ///     Console.WriteLine($"Name: {name}, Version: {version}");
+    /// }
+    /// </code>
+    /// </example>
+    public static bool TryGetNameAndVersionBundle(string fileName, out string name, out string semanticVersion)
+    {
+        name = null;
+        semanticVersion = null;
+
+        var match = System.Text.RegularExpressions.Regex.Match(fileName, pattern);
+        if (match.Success)
+        {
+            name = match.Groups[1].Value;
+            semanticVersion = match.Groups[2].Value;
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
### Features
- Support install `{name}.{version}.bundle.zip` format and remove `{version}` when install bundle.
### Updates
- Add `NameAndVersionBundleUtils` to parse bundle name and version from file name.
### Tests
- Add unit tests for `NameAndVersionBundleUtils`.