### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.1.0] / 2026-01-23
 ### Features
+- Support download bundle with parameters in the url and local file path.
 ### Fixes
 - Fix `Console` not supporting colors in some terminals. (Fix: #7)
+### Updates
+- Update `NameAndVersionBundleUtils` with `RemoveVersionBundle` to remove version from bundle file name.
+### Tests
+- Add `BundleDownloadTests` to test download url with parameters.
+- Add `UriTests` to test uri with local files or urls.
 
 ## [1.0.5] / 2025-11-03
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `Console` not supporting colors in some terminals. (Fix: #7)
 ### Updates
 - Update `NameAndVersionBundleUtils` with `RemoveVersionBundle` to remove version from bundle file name.
+- Update `BundleDownloadUtils` to support download url with parameters and local file path.
 ### Tests
 - Add `BundleDownloadTests` to test download url with parameters.
 - Add `UriTests` to test uri with local files or urls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] / 2026-01-23
+### Features
+### Fixes
+- Fix `Console` not supporting colors in some terminals. (Fix: #7)
+
 ## [1.0.5] / 2025-11-03
 ### Features
 - Support install `{name}.{version}.bundle.zip` format and remove `{version}` when install bundle.
@@ -61,6 +66,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `DownloadUtils` to support local file.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.1.0]: ../../compare/1.0.5...1.1.0
 [1.0.5]: ../../compare/1.0.4...1.0.5
 [1.0.4]: ../../compare/1.0.3...1.0.4
 [1.0.3]: ../../compare/1.0.2...1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0] / 2026-01-23
 ### Features
 - Support download bundle with parameters in the url and local file path.
+- Support download from redirect url and validate zip file. `BundleUri`
 ### Fixes
 - Fix `Console` not supporting colors in some terminals. (Fix: #7)
 ### Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Updates
 - Update `NameAndVersionBundleUtils` with `RemoveVersionBundle` to remove version from bundle file name.
 - Update `BundleDownloadUtils` to support download url with parameters and local file path.
+- Update `BundleDownloadUtils` to use `BundleUri` with handling local file or url.
+- Update `BundleUri` to validate `zip` file when downloading from url.
 ### Tests
 - Add `BundleDownloadTests` to test download url with parameters.
 - Add `UriTests` to test uri with local files or urls.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-alpha</Version>
+    <Version>1.1.0-beta</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-rc</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-beta.10</Version>
+    <Version>1.1.0-rc</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-beta</Version>
+    <Version>1.1.0-beta.1</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.1.0-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.0-beta.1</Version>
+    <Version>1.1.0-beta.10</Version>
   </PropertyGroup>
 </Project>

--- a/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
+++ b/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using ricaun.AppBundleTool.Utils;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -15,14 +16,14 @@ namespace ricaun.AppBundleTool.Tests
             var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
             try
             {
-                System.Console.WriteLine(path);
-                Assert.IsTrue(System.IO.File.Exists(path), "Downloaded file should exist.");
+                Console.WriteLine(path);
+                Assert.IsTrue(File.Exists(path), "Downloaded file should exist.");
             }
             finally
             {
-                if (System.IO.File.Exists(path))
+                if (File.Exists(path))
                 {
-                    System.IO.File.Delete(path);
+                    File.Delete(path);
                 }
             }
         }
@@ -34,28 +35,28 @@ namespace ricaun.AppBundleTool.Tests
             var bundleUri = "https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip";
             var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
 
-            var tempDirectory = System.IO.Path.GetTempPath();
-            var pathMove = System.IO.Path.Combine(tempDirectory, fileName);
-            if (System.IO.File.Exists(pathMove))
-                System.IO.File.Delete(pathMove);
-            System.IO.File.Move(path, pathMove);
+            var tempDirectory = Path.GetTempPath();
+            var pathMove = Path.Combine(tempDirectory, fileName);
+            if (File.Exists(pathMove))
+                File.Delete(pathMove);
+            File.Move(path, pathMove);
 
             try
             {
-                System.Console.WriteLine(pathMove);
-                Assert.IsFalse(System.IO.File.Exists(path), "Downloaded file should exist.");
-                Assert.IsTrue(System.IO.File.Exists(pathMove), "Downloaded file should exist.");
+                Console.WriteLine(pathMove);
+                Assert.IsFalse(File.Exists(path), "Downloaded file should exist.");
+                Assert.IsTrue(File.Exists(pathMove), "Downloaded file should exist.");
 
-                Assert.AreEqual(fileName, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+                Assert.AreEqual(fileName, Path.GetFileName(pathMove), "File name should match expected.");
 
                 pathMove = await BundleDownloadUtils.DownloadAsync(pathMove);
 
-                Assert.AreEqual(expected, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+                Assert.AreEqual(expected, Path.GetFileName(pathMove), "File name should match expected.");
             }
             finally
             {
-                if (System.IO.File.Exists(pathMove))
-                    System.IO.File.Delete(pathMove);
+                if (File.Exists(pathMove))
+                    File.Delete(pathMove);
             }
         }
 
@@ -66,27 +67,27 @@ namespace ricaun.AppBundleTool.Tests
             var bundleUri = "https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip";
             var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
 
-            var pathMove = System.IO.Path.GetFullPath(fileName);
-            if (System.IO.File.Exists(pathMove))
-                System.IO.File.Delete(pathMove);
-            System.IO.File.Move(path, pathMove);
+            var pathMove = Path.GetFullPath(fileName);
+            if (File.Exists(pathMove))
+                File.Delete(pathMove);
+            File.Move(path, pathMove);
 
             try
             {
-                System.Console.WriteLine(pathMove);
-                Assert.IsFalse(System.IO.File.Exists(path), "Downloaded file should exist.");
-                Assert.IsTrue(System.IO.File.Exists(pathMove), "Downloaded file should exist.");
+                Console.WriteLine(pathMove);
+                Assert.IsFalse(File.Exists(path), "Downloaded file should exist.");
+                Assert.IsTrue(File.Exists(pathMove), "Downloaded file should exist.");
 
-                Assert.AreEqual(fileName, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+                Assert.AreEqual(fileName, Path.GetFileName(pathMove), "File name should match expected.");
 
                 pathMove = await BundleDownloadUtils.DownloadAsync(pathMove);
 
-                Assert.AreEqual(expected, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+                Assert.AreEqual(expected, Path.GetFileName(pathMove), "File name should match expected.");
             }
             finally
             {
-                if (System.IO.File.Exists(pathMove))
-                    System.IO.File.Delete(pathMove);
+                if (File.Exists(pathMove))
+                    File.Delete(pathMove);
             }
         }
 
@@ -95,9 +96,9 @@ namespace ricaun.AppBundleTool.Tests
         [TestCase("file.zip")]
         [TestCase("file2.zip")]
         [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle")]
-        public async Task Download_Test_FileNotFoundException(string bundleUri)
+        public async Task Download_Test_Exception(string bundleUri)
         {
-            Assert.ThrowsAsync<FileNotFoundException>(async () =>
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await BundleDownloadUtils.DownloadAsync(bundleUri);
             });

--- a/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
+++ b/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
@@ -103,5 +103,15 @@ namespace ricaun.AppBundleTool.Tests
                 await BundleDownloadUtils.DownloadAsync(bundleUri);
             });
         }
+
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("https://github.com/ricaun-io/AnyUrl.bundle.zip")]
+        public async Task Download_Test_Exception_FileNotValidZip(string bundleUri)
+        {
+            Assert.ThrowsAsync<System.Net.Http.HttpRequestException>(async () =>
+            {
+                await BundleDownloadUtils.DownloadAsync(bundleUri);
+            });
+        }
     }
 }

--- a/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
+++ b/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using ricaun.AppBundleTool.Utils;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace ricaun.AppBundleTool.Tests
@@ -9,7 +10,7 @@ namespace ricaun.AppBundleTool.Tests
         [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/download/1.1.0/RevitAddin.CommandLoader.bundle.zip")]
         [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip")]
         [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip?test=123")]
-        public async Task SampleDownloadTest(string bundleUri)
+        public async Task Download_Test(string bundleUri)
         {
             var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
             try
@@ -24,6 +25,82 @@ namespace ricaun.AppBundleTool.Tests
                     System.IO.File.Delete(path);
                 }
             }
+        }
+
+        [TestCase("RevitAddin.CommandLoader.1.1.0.bundle.zip", "RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("RevitAddin.CommandLoader.bundle.zip", "RevitAddin.CommandLoader.bundle.zip")]
+        public async Task Download_FileAbsolute_Test(string fileName, string expected)
+        {
+            var bundleUri = "https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip";
+            var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
+
+            var tempDirectory = System.IO.Path.GetTempPath();
+            var pathMove = System.IO.Path.Combine(tempDirectory, fileName);
+            if (System.IO.File.Exists(pathMove))
+                System.IO.File.Delete(pathMove);
+            System.IO.File.Move(path, pathMove);
+
+            try
+            {
+                System.Console.WriteLine(pathMove);
+                Assert.IsFalse(System.IO.File.Exists(path), "Downloaded file should exist.");
+                Assert.IsTrue(System.IO.File.Exists(pathMove), "Downloaded file should exist.");
+
+                Assert.AreEqual(fileName, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+
+                pathMove = await BundleDownloadUtils.DownloadAsync(pathMove);
+
+                Assert.AreEqual(expected, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+            }
+            finally
+            {
+                if (System.IO.File.Exists(pathMove))
+                    System.IO.File.Delete(pathMove);
+            }
+        }
+
+        [TestCase("RevitAddin.CommandLoader.1.1.0.bundle.zip", "RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("RevitAddin.CommandLoader.bundle.zip", "RevitAddin.CommandLoader.bundle.zip")]
+        public async Task Download_FileRelative_Test(string fileName, string expected)
+        {
+            var bundleUri = "https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip";
+            var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
+
+            var pathMove = System.IO.Path.GetFullPath(fileName);
+            if (System.IO.File.Exists(pathMove))
+                System.IO.File.Delete(pathMove);
+            System.IO.File.Move(path, pathMove);
+
+            try
+            {
+                System.Console.WriteLine(pathMove);
+                Assert.IsFalse(System.IO.File.Exists(path), "Downloaded file should exist.");
+                Assert.IsTrue(System.IO.File.Exists(pathMove), "Downloaded file should exist.");
+
+                Assert.AreEqual(fileName, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+
+                pathMove = await BundleDownloadUtils.DownloadAsync(pathMove);
+
+                Assert.AreEqual(expected, System.IO.Path.GetFileName(pathMove), "File name should match expected.");
+            }
+            finally
+            {
+                if (System.IO.File.Exists(pathMove))
+                    System.IO.File.Delete(pathMove);
+            }
+        }
+
+        [TestCase(@"C:\path\to\file.zip")]
+        [TestCase(@"C:\path\to\file2.zip")]
+        [TestCase("file.zip")]
+        [TestCase("file2.zip")]
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle")]
+        public async Task Download_Test_FileNotFoundException(string bundleUri)
+        {
+            Assert.ThrowsAsync<FileNotFoundException>(async () =>
+            {
+                await BundleDownloadUtils.DownloadAsync(bundleUri);
+            });
         }
     }
 }

--- a/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
+++ b/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using ricaun.AppBundleTool.Utils;
+using System.Threading.Tasks;
+
+namespace ricaun.AppBundleTool.Tests
+{
+    public class BundleDownloadTests
+    {
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/download/1.1.0/RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip?test=123")]
+        public async Task SampleDownloadTest(string bundleUri)
+        {
+            var path = await DownloadUtils.DownloadAsync(bundleUri);
+            try
+            {
+                System.Console.WriteLine(path);
+                Assert.IsTrue(System.IO.File.Exists(path), "Downloaded file should exist.");
+            }
+            finally
+            {
+                if (System.IO.File.Exists(path))
+                {
+                    System.IO.File.Delete(path);
+                }
+            }
+        }
+    }
+}

--- a/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
+++ b/ricaun.AppBundleTool.Tests/BundleDownloadTests.cs
@@ -11,7 +11,7 @@ namespace ricaun.AppBundleTool.Tests
         [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/latest/download/RevitAddin.CommandLoader.bundle.zip?test=123")]
         public async Task SampleDownloadTest(string bundleUri)
         {
-            var path = await DownloadUtils.DownloadAsync(bundleUri);
+            var path = await BundleDownloadUtils.DownloadAsync(bundleUri);
             try
             {
                 System.Console.WriteLine(path);

--- a/ricaun.AppBundleTool.Tests/NameAndVersionTests.cs
+++ b/ricaun.AppBundleTool.Tests/NameAndVersionTests.cs
@@ -37,5 +37,34 @@ namespace ricaun.AppBundleTool.Tests
             Assert.IsNull(name);
             Assert.IsNull(version);
         }
+
+        [TestCase("MyLib.1.2.3.bundle", "MyLib.bundle")]
+        [TestCase("Plugin.3.4.5-beta.bundle", "Plugin.bundle")]
+        [TestCase("My.Lib.Core.2.0.0.bundle", "My.Lib.Core.bundle")]
+        [TestCase("ToolName.10.0.1-alpha.bundle", "ToolName.bundle")]
+        [TestCase("Library.1.0.0.1.bundle", "Library.bundle")] // supports 4 numeric parts
+        [TestCase("MyLib.bundle", "MyLib.bundle")]
+        [TestCase("MyLib.bundle.zip", "MyLib.bundle.zip")]
+        [TestCase("MyLib.1.2.3.bundle.zip", "MyLib.bundle.zip")]
+        public void RemoveVersionBundle_ValidNames(string fileName, string expectedName)
+        {
+            // Act
+            var result = NameAndVersionBundleUtils.RemoveVersionBundle(fileName);
+
+            // Assert
+            Assert.AreEqual(expectedName, result);
+        }
+
+        [TestCase("MyLib 1.2.3.bundle.zip")]
+        [TestCase("MyLib.test")]
+        public void RemoveVersionBundle_NotValidNames(string fileName)
+        {
+            // Act
+            var result = NameAndVersionBundleUtils.RemoveVersionBundle(fileName);
+
+            // Assert
+            var expectedName = fileName;
+            Assert.AreEqual(expectedName, result);
+        }
     }
 }

--- a/ricaun.AppBundleTool.Tests/UriTests.cs
+++ b/ricaun.AppBundleTool.Tests/UriTests.cs
@@ -1,0 +1,41 @@
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace ricaun.AppBundleTool.Tests
+{
+    public class UriTests
+    {
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/download/1.1.0/RevitAddin.CommandLoader.bundle.zip")]
+        [TestCase("https://github.com/ricaun-io/RevitAddin.CommandLoader/releases/download/1.1.0/RevitAddin.CommandLoader.bundle.zip?test=123")]
+        public void UriAbsoluteTest(string bundleUri)
+        {
+            var uri = new Uri(bundleUri, UriKind.Absolute);
+            Assert.AreEqual("github.com", uri.Host, "Host should be github.com");
+            Assert.IsTrue(uri.IsAbsoluteUri, "URI should be absolute.");
+            Assert.IsFalse(uri.IsFile, "URI should not be a file.");
+            Assert.IsTrue(uri.AbsolutePath.EndsWith(".zip"), "Path should end with .zip");
+        }
+
+        [TestCase(@"C:\path\to\file.zip")]
+        [TestCase(@"C:\path\to\file2.zip")]
+        public void UriAbsoluteFileTest(string bundleUri)
+        {
+            var uri = new Uri(bundleUri, UriKind.Absolute);
+            Assert.IsTrue(uri.IsAbsoluteUri, "URI should be absolute.");
+            Assert.IsTrue(uri.IsFile, "URI should be a file.");
+            Assert.IsTrue(uri.AbsolutePath.EndsWith(".zip"), "Path should end with .zip");
+        }
+
+        [TestCase("file.zip")]
+        [TestCase("file2.zip")]
+        public void UriRelativeTest(string bundleUri)
+        {
+            var uri = new Uri(bundleUri, UriKind.Relative);
+            Assert.IsFalse(uri.IsAbsoluteUri, "URI should be relative.");
+            Assert.IsTrue(uri.OriginalString.EndsWith(".zip"), "Path should end with .zip");
+            var fullPath = Path.GetFullPath(uri.OriginalString);
+            Assert.IsTrue(fullPath.EndsWith(".zip"), "Full path should end with .zip");
+        }
+    }
+}

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -22,8 +22,24 @@ namespace ricaun.AppBundleTool
 #endif
             var parser = Options.Parser.ParseArguments<Options>(args);
             displayHelp = DisplayHelp(parser);
-            parser.WithParsed<Options>(ExecuteCommand)
+            parser.WithParsed<Options>(ExecuteCommandException)
                   .WithNotParsed(ExecuteError);
+        }
+
+        private static void ExecuteCommandException(Options options)
+        {
+            try
+            {
+                ExecuteCommand(options);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message.ToConsoleRed()}");
+                if (options.Verbosity)
+                {
+                    Console.WriteLine(ex.ToConsoleYellow());
+                }
+            }
         }
 
         private static void ExecuteCommand(Options options)

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -183,12 +183,12 @@ namespace ricaun.AppBundleTool
             var downloadProgress = $"Download: {bundleName.ToConsoleGreen()}";
 
             var processPercentage = "";
-            DownloadUtils.DownloadProgress = (value, total) =>
+            BundleDownloadUtils.DownloadProgress = (value, total) =>
             {
                 if (total > 0)
                     processPercentage = $"{100.0 * value / total:0.00}%";
             };
-            var bundlePathZip = DownloadUtils.DownloadAsync(bundleUrl).ConsoleWaitResult(downloadProgress, () => { return processPercentage; });
+            var bundlePathZip = BundleDownloadUtils.DownloadAsync(bundleUrl).ConsoleWaitResult(downloadProgress, () => { return processPercentage; });
 
             var bundlePathFolderName = Path.GetFileNameWithoutExtension(bundlePathZip);
             if (NameAndVersionBundleUtils.TryGetNameAndVersionBundle(bundlePathFolderName, out string name, out string _))

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -63,7 +63,6 @@ namespace ricaun.AppBundleTool
         {
             var bundle = new BundleUri(options.App);
             var appBundleName = bundle.AppName;
-                Console.WriteLine($"{bundle.BundleNameZip} {bundle.BundleName} {bundle.AppName} {bundle.IsValid()}");
             if (bundle.IsValid())
             {
                 if (options.Install)

--- a/ricaun.AppBundleTool/Program.cs
+++ b/ricaun.AppBundleTool/Program.cs
@@ -51,17 +51,24 @@ namespace ricaun.AppBundleTool
             }
             else if (string.IsNullOrWhiteSpace(options.App) == false)
             {
-                var appBundleName = Path.GetFileName(options.App);
+                ExecuteApp(options);
+            }
+            else
+            {
+                Console.WriteLine(displayHelp);
+            }
+        }
+
+        private static void ExecuteApp(Options options)
+        {
+            var bundle = new BundleUri(options.App);
+            var appBundleName = bundle.AppName;
+                Console.WriteLine($"{bundle.BundleNameZip} {bundle.BundleName} {bundle.AppName} {bundle.IsValid()}");
+            if (bundle.IsValid())
+            {
                 if (options.Install)
                 {
-                    if (Path.GetExtension(appBundleName) != ".zip")
-                    {
-                        Console.WriteLine($"'{appBundleName}' need to be 'zip' extension.".ToConsoleRed());
-                        return;
-                    }
-
-                    var bundleUrl = options.App;
-                    var appBundleInfoTemp = DownloadAppBundleInfo(bundleUrl);
+                    var appBundleInfoTemp = DownloadBundleUriToTemp(bundle);
                     var applicationPluginsFolder = AppBundleFolder.AppData.GetApplicationPlugins();
 
                     appBundleName = appBundleInfoTemp.ApplicationPackage.Name;
@@ -96,27 +103,6 @@ namespace ricaun.AppBundleTool
                 }
                 else if (options.Uninstall)
                 {
-                    if (Path.GetExtension(appBundleName) == ".zip")
-                    {
-                        var bundleUrl = options.App;
-                        var appBundleInfoTemp = DownloadAppBundleInfo(bundleUrl);
-                        if (appBundleInfoTemp is null)
-                        {
-                            Console.WriteLine($"AppBundle '{bundleUrl}' not found.".ToConsoleRed());
-                            return;
-                        }
-
-                        if (appBundleInfoTemp.IsValid())
-                        {
-                            appBundleName = appBundleInfoTemp.ApplicationPackage.Name;
-                        }
-                        else
-                        {
-                            Console.WriteLine($"AppBundleInfo '{appBundleInfoTemp.Name}' not valid.".ToConsoleRed());
-                            return;
-                        }
-                    }
-
                     var appBundle = AppBundleUtils.FindAppBundle(appBundleName);
                     if (appBundle is null)
                     {
@@ -128,44 +114,61 @@ namespace ricaun.AppBundleTool
 
                     UninstallAppBundle(appBundle);
                 }
-                else if (Path.GetExtension(appBundleName) == ".zip")
-                {
-                    var bundleUrl = options.App;
-                    var appBundleInfoTemp = DownloadAppBundleInfo(bundleUrl);
-                    if (appBundleInfoTemp.IsValid())
-                    {
-                        appBundleName = appBundleInfoTemp.ApplicationPackage.Name;
-                        var appBundleInfo = AppBundleUtils.FindAppBundleByAppName(appBundleName);
-                        if (appBundleInfo is null)
-                        {
-                            Console.WriteLine($"AppBundle '{appBundleName}' not found.".ToConsoleRed());
-                            return;
-                        }
-                        appBundleInfo.Show(Verbosity);
-                    }
-                    else
-                    {
-                        Console.WriteLine($"AppBundleInfo '{appBundleInfoTemp.Name}' not valid.".ToConsoleRed());
-                        return;
-                    }
-                }
                 else
                 {
                     var appBundleInfo = AppBundleUtils.FindAppBundle(appBundleName);
                     if (appBundleInfo is null)
                     {
-                        Show();
-                        Console.WriteLine($"AppBundle '{appBundleName}' not found.".ToConsoleYellow());
+                        Console.WriteLine($"AppBundle '{appBundleName}' not found.".ToConsoleRed());
                         return;
                     }
-
                     appBundleInfo.Show(Verbosity);
                 }
+                return;
             }
             else
             {
-                Console.WriteLine(displayHelp);
+                var appBundleInfo = AppBundleUtils.FindAppBundle(bundle.BundleName);
+                if (appBundleInfo is null)
+                {
+                    Show();
+                    Console.WriteLine($"AppBundle '{bundle.BundleName}' not found.".ToConsoleYellow());
+                    return;
+                }
+
+                appBundleInfo.Show(Verbosity);
             }
+        }
+
+        private static AppBundleInfo DownloadBundleUriToTemp(BundleUri bundle)
+        {
+            var downloadProgress = $"Download: {bundle.BundleName.ToConsoleGreen()}";
+            var processPercentage = "";
+            Action<long, long> progress = (value, total) =>
+            {
+                if (total > 0)
+                    processPercentage = $"{100.0 * value / total:0.00}%";
+            };
+            var tempFolder = BundleDownloadUtils.GetTempFolder();
+            var bundlePathZip = bundle.DownloadAsync(tempFolder, progress)
+                .ConsoleWaitResult(downloadProgress, () => { return processPercentage; });
+
+            var bundlePathFolderName = Path.GetFileNameWithoutExtension(bundlePathZip);
+
+            // unzip file to folder
+            var bundlePathFolder = Path.Combine(Path.GetDirectoryName(bundlePathZip), bundlePathFolderName);
+            if (Directory.Exists(bundlePathFolder))
+                Directory.Delete(bundlePathFolder, true);
+
+            var extractProgress = $"Extract: {bundle.BundleName.ToConsoleGreen()}";
+            Task.Run(() =>
+            {
+                ZipFile.ExtractToDirectory(bundlePathZip, bundlePathFolder, true);
+                return true;
+            }).ConsoleWaitResult(extractProgress);
+
+            var tempAppBundleInfo = AppBundleInfo.FindAppBundle(bundlePathFolder);
+            return tempAppBundleInfo;
         }
 
         private static void UninstallAppBundle(AppBundleInfo appBundle)
@@ -190,46 +193,6 @@ namespace ricaun.AppBundleTool
             catch (Exception)
             {
                 Console.WriteLine($"Fail to send to Recycle Bin: {appBundle.PathPackageContents}".ToConsoleRed());
-            }
-        }
-
-        private static AppBundleInfo DownloadAppBundleInfo(string bundleUrl)
-        {
-            var bundleName = Path.GetFileName(bundleUrl);
-            var downloadProgress = $"Download: {bundleName.ToConsoleGreen()}";
-
-            var processPercentage = "";
-            BundleDownloadUtils.DownloadProgress = (value, total) =>
-            {
-                if (total > 0)
-                    processPercentage = $"{100.0 * value / total:0.00}%";
-            };
-            var bundlePathZip = BundleDownloadUtils.DownloadAsync(bundleUrl).ConsoleWaitResult(downloadProgress, () => { return processPercentage; });
-
-            var bundlePathFolderName = Path.GetFileNameWithoutExtension(bundlePathZip);
-            if (NameAndVersionBundleUtils.TryGetNameAndVersionBundle(bundlePathFolderName, out string name, out string _))
-                bundlePathFolderName = name + Path.GetExtension(bundlePathFolderName);
-
-            // unzip file to folder
-            var bundlePathFolder = Path.Combine(Path.GetDirectoryName(bundlePathZip), bundlePathFolderName);
-            if (Directory.Exists(bundlePathFolder))
-                Directory.Delete(bundlePathFolder, true);
-
-            var extractProgress = $"Extract: {bundleName.ToConsoleGreen()}";
-            Task.Run(() =>
-            {
-                ZipFile.ExtractToDirectory(bundlePathZip, bundlePathFolder, true);
-                return true;
-            }).ConsoleWaitResult(extractProgress);
-
-            return AppBundleInfo.FindAppBundle(bundlePathFolder);
-        }
-
-        public static void WriteLine(object message)
-        {
-            if (Verbosity)
-            {
-                Console.WriteLine(message);
             }
         }
 

--- a/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
+++ b/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
@@ -8,7 +8,7 @@ namespace ricaun.AppBundleTool.Utils
     /// <summary>
     /// Provides utility methods for downloading files and managing temporary folders.
     /// </summary>
-    public static class DownloadUtils
+    public static class BundleDownloadUtils
     {
         /// <summary>
         /// The name of the temporary folder used for downloads.

--- a/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
+++ b/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
@@ -73,7 +73,7 @@ namespace ricaun.AppBundleTool.Utils
             {
                 throw new ArgumentException("Invalid bundle URI.", nameof(bundleUri));
             }
-
+            
             if (!uri.IsAbsoluteUri) // Relative URI
             {
                 var appBundleName = Path.GetFileName(uri.OriginalString);
@@ -92,9 +92,23 @@ namespace ricaun.AppBundleTool.Utils
                 }
                 throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
             }
+            else if (uri.IsFile) // File URI
+            {
+                var appBundleName = Path.GetFileName(uri.LocalPath);
+                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
+                if (Path.GetExtension(appBundleName) != ".zip")
+                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
+                var bundlePath = Path.Combine(tempFolder, appBundleName);
+                var fullPath = uri.LocalPath;
+                if (File.Exists(fullPath))
+                {
+                    File.Copy(fullPath, bundlePath, true);
+                    return bundlePath;
+                }
+                throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
+            }
             else
             {
-
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
 

--- a/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
+++ b/ricaun.AppBundleTool/Utils/BundleDownloadUtils.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace ricaun.AppBundleTool.Utils
 {
     /// <summary>
-    /// Provides utility methods for downloading files and managing temporary folders.
+    /// Provides utility methods for downloading bundle files.
     /// </summary>
     public static class BundleDownloadUtils
     {
         /// <summary>
-        /// The name of the temporary folder used for downloads.
+        /// The name of the temporary folder used for storing downloaded bundles.
         /// </summary>
-        public const string TempFolder = "ricaun.AppBundleTool";
-        private const double CACHE_TOTAL_MINUTES = 1 / 60;
+        private const string TempFolder = "ricaun.AppBundleTool";
 
         /// <summary>
         /// Gets the path to the temporary folder, creating it if it does not exist.
@@ -47,131 +45,36 @@ namespace ricaun.AppBundleTool.Utils
         }
 
         /// <summary>
-        /// Downloads a file from the specified URI to the temporary folder.
+        /// Downloads a bundle file asynchronously from the specified URI.
         /// </summary>
-        /// <param name="bundleUri">The URI of the file to download.</param>
-        /// <param name="authentication">Optional authentication token.</param>
-        /// <param name="cacheTotalMinutes">The number of minutes to cache the downloaded file before re-downloading.</param>
-        /// <returns>The path to the downloaded file.</returns>
-        public static async Task<string> DownloadAsync(string bundleUri, string authentication = null, double cacheTotalMinutes = CACHE_TOTAL_MINUTES)
+        /// <param name="bundleUri">The URI of the bundle file to download. Must end with '.bundle.zip'.</param>
+        /// <param name="authentication">The authentication token or credentials (optional).</param>
+        /// <returns>A task that represents the asynchronous download operation. The task result contains the local file path of the downloaded bundle.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the bundle URI is not valid or does not end with '.bundle.zip'.</exception>
+        public static async Task<string> DownloadAsync(string bundleUri, string authentication = null)
         {
-            var tempFolder = GetTempFolder();
-            return await DownloadAsync(tempFolder, bundleUri, authentication, cacheTotalMinutes);
-        }
-
-        /// <summary>
-        /// Downloads a file from the specified URI to the specified folder.
-        /// </summary>
-        /// <param name="tempFolder">The folder to download the file to.</param>
-        /// <param name="bundleUri">The URI of the file to download.</param>
-        /// <param name="authentication">Optional authentication token.</param>
-        /// <param name="cacheTotalMinutes">The number of minutes to cache the downloaded file before re-downloading.</param>
-        /// <returns>The path to the downloaded file.</returns>
-        private static async Task<string> DownloadAsync(string tempFolder, string bundleUri, string authentication = null, double cacheTotalMinutes = CACHE_TOTAL_MINUTES)
-        {
-            if (!Uri.TryCreate(bundleUri, UriKind.RelativeOrAbsolute, out var uri))
+            using (var bundle = new BundleUri(bundleUri))
             {
-                throw new ArgumentException("Invalid bundle URI.", nameof(bundleUri));
-            }
-            
-            if (!uri.IsAbsoluteUri) // Relative URI
-            {
-                var appBundleName = Path.GetFileName(uri.OriginalString);
-
-                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
-
-                if (Path.GetExtension(appBundleName) != ".zip")
-                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
-
-                var bundlePath = Path.Combine(tempFolder, appBundleName);
-                var fullPath = Path.GetFullPath(uri.OriginalString);
-                if (File.Exists(fullPath))
+                try
                 {
-                    File.Copy(fullPath, bundlePath, true);
-                    return bundlePath;
+                    if (!bundle.IsValid())
+                    {
+                        throw new InvalidOperationException("The bundle URI is not valid, does not end with '.bundle.zip'");
+                    }
+                    return await bundle.DownloadAsync(GetTempFolder(), progress: DownloadProgress);
                 }
-                throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
-            }
-            else if (uri.IsFile) // File URI
-            {
-                var appBundleName = Path.GetFileName(uri.LocalPath);
-                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
-                if (Path.GetExtension(appBundleName) != ".zip")
-                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
-                var bundlePath = Path.Combine(tempFolder, appBundleName);
-                var fullPath = uri.LocalPath;
-                if (File.Exists(fullPath))
+                finally
                 {
-                    File.Copy(fullPath, bundlePath, true);
-                    return bundlePath;
+                    DownloadProgress = null;
                 }
-                throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
-            }
-            else
-            {
-                using var client = new HttpClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
-
-                if (string.IsNullOrWhiteSpace(authentication) == false)
-                    client.DefaultRequestHeaders.Add("Authorization", $"Bearer {authentication}");
-
-                var response = await client.GetAsync(bundleUri, HttpCompletionOption.ResponseHeadersRead);
-
-                // Total size (might be null if server doesn't send Content-Length)
-                var contentLengthHeader = response.Content.Headers.ContentLength;
-                var contentLength = contentLengthHeader.HasValue ? contentLengthHeader.Value : -1L;
-
-                var appBundleName = Path.GetFileName(uri.LocalPath);
-
-                // Check Content-Disposition
-                if (response.Content.Headers.ContentDisposition?.FileName is not null)
-                {
-                    appBundleName = response.Content.Headers.ContentDisposition.FileName.Trim('\"');
-                }
-
-                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
-
-                if (Path.GetExtension(appBundleName) != ".zip")
-                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
-
-                var bundlePath = Path.Combine(tempFolder, appBundleName);
-
-                //if (File.Exists(bundlePath))
-                //{
-                //    var lastTime = File.GetLastWriteTime(bundlePath);
-                //    var now = DateTime.Now;
-                //    var diff = now - lastTime;
-                //    if (diff.TotalMinutes < cacheTotalMinutes)
-                //    {
-                //        return bundlePath;
-                //    }
-                //}
-
-                await using var contentStream = await response.Content.ReadAsStreamAsync();
-                await using var fileStream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
-
-                var buffer = new byte[81920]; // 80 KB chunks
-                long totalRead = 0;
-                int read;
-                DownloadProgress?.Invoke(totalRead, contentLength);
-                do
-                {
-                    read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length));
-                    if (read == 0) break;
-
-                    await fileStream.WriteAsync(buffer.AsMemory(0, read));
-                    totalRead += read;
-
-                    DownloadProgress?.Invoke(totalRead, contentLength);
-                } while (true);
-
-                return bundlePath;
             }
         }
-
         /// <summary>
-        /// An action that reports download progress. (total bytes downloaded, total bytes to download)
+        /// Gets or sets an action that reports download progress.
         /// </summary>
+        /// <value>
+        /// An action with two parameters: the total bytes downloaded and the total bytes to download.
+        /// </value>
         public static Action<long, long> DownloadProgress { get; set; }
     }
 }

--- a/ricaun.AppBundleTool/Utils/BundleUri.cs
+++ b/ricaun.AppBundleTool/Utils/BundleUri.cs
@@ -18,7 +18,17 @@ namespace ricaun.AppBundleTool.Utils
         /// <summary>
         /// Gets the name of the bundle file without version information.
         /// </summary>
+        public string BundleNameZip { get; }
+
+        /// <summary>
+        /// Gets the base name of the bundle without the .zip extension.
+        /// </summary>
         public string BundleName { get; }
+
+        /// <summary>
+        /// Gets the application name derived from the bundle name.
+        /// </summary>
+        public string AppName { get; }
 
         /// <summary>
         /// The authentication token used for HTTP requests.
@@ -54,7 +64,15 @@ namespace ricaun.AppBundleTool.Utils
         {
             this.Uri = uri;
             this.authentication = authentication;
-            this.BundleName = GetBundleName();
+            this.BundleNameZip = GetBundleName();
+            this.BundleName = this.BundleNameZip;
+            this.AppName = this.BundleName;
+
+            if (Path.GetExtension(this.BundleNameZip) == ".zip")
+                this.BundleName = Path.GetFileNameWithoutExtension(this.BundleNameZip);
+
+            if (Path.GetExtension(this.BundleName) == ".bundle")
+                this.AppName = Path.GetFileNameWithoutExtension(this.BundleName);
         }
 
         /// <summary>
@@ -80,11 +98,11 @@ namespace ricaun.AppBundleTool.Utils
         /// <returns><c>true</c> if the bundle name is valid; otherwise, <c>false</c>.</returns>
         public bool IsValid()
         {
-            if (string.IsNullOrEmpty(BundleName))
+            if (string.IsNullOrEmpty(BundleNameZip))
                 return false;
 
-            var extensionZip = Path.GetExtension(BundleName);
-            var extensionBundle = Path.GetExtension(Path.GetFileNameWithoutExtension(BundleName));
+            var extensionZip = Path.GetExtension(BundleNameZip);
+            var extensionBundle = Path.GetExtension(Path.GetFileNameWithoutExtension(BundleNameZip));
 
             return extensionZip == ".zip" && extensionBundle == ".bundle";
         }
@@ -107,7 +125,7 @@ namespace ricaun.AppBundleTool.Utils
             var fullPath = Uri.IsAbsoluteUri ? Uri.LocalPath : Path.GetFullPath(Uri.OriginalString);
             if (File.Exists(fullPath))
             {
-                var bundlePath = Path.Combine(destinationFolder, BundleName);
+                var bundlePath = Path.Combine(destinationFolder, BundleNameZip);
                 File.Copy(fullPath, bundlePath, true);
                 return bundlePath;
             }
@@ -143,7 +161,7 @@ namespace ricaun.AppBundleTool.Utils
             if (client is null)
                 await ClientGetBundleNameAsync();
 
-            var bundlePath = Path.Combine(destinationFolder, BundleName);
+            var bundlePath = Path.Combine(destinationFolder, BundleNameZip);
 
             // Total size (might be null if server doesn't send Content-Length)
             var contentLengthHeader = response.Content.Headers.ContentLength;

--- a/ricaun.AppBundleTool/Utils/BundleUri.cs
+++ b/ricaun.AppBundleTool/Utils/BundleUri.cs
@@ -1,0 +1,225 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ricaun.AppBundleTool.Utils
+{
+    /// <summary>
+    /// Represents a URI to a bundle file that can be downloaded from a remote location or accessed locally.
+    /// </summary>
+    public class BundleUri : IDisposable
+    {
+        /// <summary>
+        /// Gets the URI of the bundle.
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// Gets the name of the bundle file without version information.
+        /// </summary>
+        public string BundleName { get; }
+
+        /// <summary>
+        /// The authentication token used for HTTP requests.
+        /// </summary>
+        private string authentication;
+
+        /// <summary>
+        /// The HTTP client used for downloading remote bundles.
+        /// </summary>
+        private HttpClient client;
+
+        /// <summary>
+        /// The HTTP response message from the initial request.
+        /// </summary>
+        private HttpResponseMessage response;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BundleUri"/> class with a string URI.
+        /// </summary>
+        /// <param name="uri">The URI string of the bundle.</param>
+        /// <param name="authentication">Optional authentication token for remote downloads.</param>
+        public BundleUri(string uri, string authentication = null)
+            : this(new Uri(uri, UriKind.RelativeOrAbsolute), authentication)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BundleUri"/> class with a <see cref="Uri"/> object.
+        /// </summary>
+        /// <param name="uri">The URI of the bundle.</param>
+        /// <param name="authentication">Optional authentication token for remote downloads.</param>
+        public BundleUri(Uri uri, string authentication = null)
+        {
+            this.Uri = uri;
+            this.authentication = authentication;
+            this.BundleName = GetBundleName();
+        }
+
+        /// <summary>
+        /// Gets the bundle name from the URI, removing version information.
+        /// </summary>
+        /// <returns>The bundle file name without version information.</returns>
+        private string GetBundleName()
+        {
+            var bundleName = string.Empty;
+            if (Uri.IsAbsoluteUri)
+            {
+                bundleName = Uri.IsFile ? Path.GetFileName(Uri.LocalPath) : ClientGetBundleNameAsync().GetAwaiter().GetResult();
+            }
+            else
+            {
+                bundleName = Path.GetFileName(Uri.OriginalString);
+            }
+            return NameAndVersionBundleUtils.RemoveVersionBundle(bundleName);
+        }
+        /// <summary>
+        /// Validates whether the bundle has a valid format (*.bundle.zip).
+        /// </summary>
+        /// <returns><c>true</c> if the bundle name is valid; otherwise, <c>false</c>.</returns>
+        public bool IsValid()
+        {
+            if (string.IsNullOrEmpty(BundleName))
+                return false;
+
+            var extensionZip = Path.GetExtension(BundleName);
+            var extensionBundle = Path.GetExtension(Path.GetFileNameWithoutExtension(BundleName));
+
+            return extensionZip == ".zip" && extensionBundle == ".bundle";
+        }
+
+        /// <summary>
+        /// Downloads the bundle to the specified destination folder asynchronously.
+        /// </summary>
+        /// <param name="destinationFolder">The destination folder where the bundle will be saved. If <c>null</c>, uses a temporary folder.</param>
+        /// <param name="progress">Optional callback to report download progress. First parameter is bytes downloaded, second is total bytes (-1 if unknown).</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the full path to the downloaded bundle file.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the HttpClient is not initialized for remote downloads.</exception>
+        /// <exception cref="FileNotFoundException">Thrown when the specified local bundle file does not exist.</exception>
+        public async Task<string> DownloadAsync(string destinationFolder, Action<long, long> progress = null)
+        {
+            if (Uri.IsAbsoluteUri && !Uri.IsFile)
+            {
+                return await ClientDownloadZipAsync(destinationFolder, progress);
+            }
+
+            var fullPath = Uri.IsAbsoluteUri ? Uri.LocalPath : Path.GetFullPath(Uri.OriginalString);
+            if (File.Exists(fullPath))
+            {
+                var bundlePath = Path.Combine(destinationFolder, BundleName);
+                File.Copy(fullPath, bundlePath, true);
+                return bundlePath;
+            }
+            throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
+        }
+
+        /// <summary>
+        /// Asynchronously retrieves the bundle name from the remote server by making an HTTP request.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation. The task result contains the bundle file name.</returns>
+        private async Task<string> ClientGetBundleNameAsync()
+        {
+            client ??= new HttpClient();
+            client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
+
+            if (string.IsNullOrWhiteSpace(authentication) == false)
+                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {authentication}");
+
+            response = await client.GetAsync(Uri, HttpCompletionOption.ResponseHeadersRead);
+
+            //var contentType = response.Content.Headers.ContentType?.MediaType;
+            //Console.WriteLine(contentType);
+
+            var finalUrl = response.RequestMessage?.RequestUri ?? Uri;
+            var contentDisposition = response.Content.Headers.ContentDisposition;
+            var bundleName = contentDisposition?.FileName?.Trim('"') ?? Path.GetFileName(finalUrl.LocalPath);
+
+            return bundleName;
+        }
+
+        private async Task<string> ClientDownloadZipAsync(string destinationFolder, Action<long, long> progress)
+        {
+            if (client is null)
+                await ClientGetBundleNameAsync();
+
+            var bundlePath = Path.Combine(destinationFolder, BundleName);
+
+            // Total size (might be null if server doesn't send Content-Length)
+            var contentLengthHeader = response.Content.Headers.ContentLength;
+            var contentLength = contentLengthHeader.HasValue ? contentLengthHeader.Value : -1L;
+
+            await using var contentStream = await response.Content.ReadAsStreamAsync();
+            await using var fileStream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+            try
+            {
+                var buffer = new byte[81920]; // 80 KB chunks
+                long totalRead = 0;
+                int read;
+                progress?.Invoke(totalRead, contentLength);
+                do
+                {
+                    read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+                    if (read == 0) break;
+
+                    if (totalRead == 0)
+                    {
+                        bool isZip = IsZipFile(buffer, read);
+                        if (!isZip)
+                        {
+                            throw new HttpRequestException("The downloaded file is not a valid ZIP file.");
+                        }
+                    }
+
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read));
+                    totalRead += read;
+
+                    progress?.Invoke(totalRead, contentLength);
+                } while (true);
+            }
+            finally
+            {
+                response?.Dispose();
+                client?.Dispose();
+                client = null;
+            }
+
+            return bundlePath;
+        }
+
+        /// <summary>
+        /// Validates whether the provided byte buffer starts with a valid ZIP file signature.
+        /// </summary>
+        /// <param name="buffer">The byte array containing the file data to check.</param>
+        /// <param name="bytesRead">The number of bytes read into the buffer.</param>
+        /// <returns>
+        /// <c>true</c> if the buffer contains a valid ZIP file signature (PK + 0x03/0x05/0x07); otherwise, <c>false</c>.
+        /// </returns>
+        /// <remarks>
+        /// ZIP files start with the signature "PK" (0x50 0x4B), representing Phil Katz's initials.
+        /// The third byte indicates the ZIP variant: 0x03 for standard ZIP, 0x05 for spanned ZIP, and 0x07 for split ZIP.
+        /// </remarks>
+        private bool IsZipFile(byte[] buffer, int bytesRead)
+        {
+            return
+                bytesRead >= 4 &&
+                buffer[0] == 0x50 && // P
+                buffer[1] == 0x4B && // K
+                (
+                    buffer[2] == 0x03 ||
+                    buffer[2] == 0x05 ||
+                    buffer[2] == 0x07
+                );
+        }
+
+        /// <summary>
+        /// Releases the HTTP client and response resources.
+        /// </summary>
+        public void Dispose()
+        {
+            response?.Dispose();
+            client?.Dispose();
+        }
+    }
+}

--- a/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
+++ b/ricaun.AppBundleTool/Utils/ConsoleColorExtension.cs
@@ -89,19 +89,57 @@ namespace ricaun.AppBundleTool.Utils
             return $"{GREY}{value}{NORMAL}";
         }
 
-        static string NORMAL => Console.IsOutputRedirected ? "" : "\x1b[39m";
-        static string RED => Console.IsOutputRedirected ? "" : "\x1b[91m";
-        static string GREEN => Console.IsOutputRedirected ? "" : "\x1b[92m";
-        static string YELLOW => Console.IsOutputRedirected ? "" : "\x1b[93m";
-        static string BLUE => Console.IsOutputRedirected ? "" : "\x1b[94m";
-        static string MAGENTA => Console.IsOutputRedirected ? "" : "\x1b[95m";
-        static string CYAN => Console.IsOutputRedirected ? "" : "\x1b[96m";
-        static string GREY => Console.IsOutputRedirected ? "" : "\x1b[97m";
-        static string BOLD => Console.IsOutputRedirected ? "" : "\x1b[1m";
-        static string NOBOLD => Console.IsOutputRedirected ? "" : "\x1b[22m";
-        static string UNDERLINE => Console.IsOutputRedirected ? "" : "\x1b[4m";
-        static string NOUNDERLINE => Console.IsOutputRedirected ? "" : "\x1b[24m";
-        static string REVERSE => Console.IsOutputRedirected ? "" : "\x1b[7m";
-        static string NOREVERSE => Console.IsOutputRedirected ? "" : "\x1b[27m";
+        static string NORMAL => IsAnsiSupported ? "\x1b[39m" : string.Empty;
+        static string RED => IsAnsiSupported ? "\x1b[91m" : string.Empty;
+        static string GREEN => IsAnsiSupported ? "\x1b[92m" : string.Empty;
+        static string YELLOW => IsAnsiSupported ? "\x1b[93m" : string.Empty;
+        static string BLUE => IsAnsiSupported ? "\x1b[94m" : string.Empty;
+        static string MAGENTA => IsAnsiSupported ? "\x1b[95m" : string.Empty;
+        static string CYAN => IsAnsiSupported ? "\x1b[96m" : string.Empty;
+        static string GREY => IsAnsiSupported ? "\x1b[97m" : string.Empty;
+        static string BOLD => IsAnsiSupported ? "\x1b[1m" : string.Empty;
+        static string NOBOLD => IsAnsiSupported ? "\x1b[22m" : string.Empty;
+        static string UNDERLINE => IsAnsiSupported ? "\x1b[4m" : string.Empty;
+        static string NOUNDERLINE => IsAnsiSupported ? "\x1b[24m" : string.Empty;
+        static string REVERSE => IsAnsiSupported ? "\x1b[7m" : string.Empty;
+        static string NOREVERSE => IsAnsiSupported ? "\x1b[27m" : string.Empty;
+
+        internal static bool IsAnsiSupported { get; } = SupportsAnsi();
+        internal static bool SupportsAnsi()
+        {
+            if (Console.IsOutputRedirected)
+                return false;
+
+            if (!OperatingSystem.IsWindows())
+                return true;
+
+            if (!OperatingSystem.IsWindowsVersionAtLeast(10))
+                return false;
+
+            return Windows.IsAnsiEnabledOnWindows();
+        }
+        static class Windows
+        {
+            internal static bool IsAnsiEnabledOnWindows()
+            {
+                const int STD_OUTPUT_HANDLE = -11;
+                const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+
+                IntPtr handle = GetStdHandle(STD_OUTPUT_HANDLE);
+                if (handle == IntPtr.Zero)
+                    return false;
+
+                if (!GetConsoleMode(handle, out uint mode))
+                    return false;
+
+                return (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
+            }
+
+            [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+            static extern IntPtr GetStdHandle(int nStdHandle);
+
+            [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+            static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+        }
     }
 }

--- a/ricaun.AppBundleTool/Utils/DownloadUtils.cs
+++ b/ricaun.AppBundleTool/Utils/DownloadUtils.cs
@@ -77,6 +77,9 @@ namespace ricaun.AppBundleTool.Utils
             if (!uri.IsAbsoluteUri) // Relative URI
             {
                 var appBundleName = Path.GetFileName(uri.OriginalString);
+
+                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
+
                 if (Path.GetExtension(appBundleName) != ".zip")
                     throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
 
@@ -91,7 +94,6 @@ namespace ricaun.AppBundleTool.Utils
             }
             else
             {
-                var appBundleName = Path.GetFileName(uri.LocalPath);
 
                 using var client = new HttpClient();
                 client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
@@ -105,11 +107,15 @@ namespace ricaun.AppBundleTool.Utils
                 var contentLengthHeader = response.Content.Headers.ContentLength;
                 var contentLength = contentLengthHeader.HasValue ? contentLengthHeader.Value : -1L;
 
+                var appBundleName = Path.GetFileName(uri.LocalPath);
+
                 // Check Content-Disposition
                 if (response.Content.Headers.ContentDisposition?.FileName is not null)
                 {
                     appBundleName = response.Content.Headers.ContentDisposition.FileName.Trim('\"');
                 }
+
+                appBundleName = NameAndVersionBundleUtils.RemoveVersionBundle(appBundleName);
 
                 if (Path.GetExtension(appBundleName) != ".zip")
                     throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);

--- a/ricaun.AppBundleTool/Utils/DownloadUtils.cs
+++ b/ricaun.AppBundleTool/Utils/DownloadUtils.cs
@@ -69,65 +69,84 @@ namespace ricaun.AppBundleTool.Utils
         /// <returns>The path to the downloaded file.</returns>
         private static async Task<string> DownloadAsync(string tempFolder, string bundleUri, string authentication = null, double cacheTotalMinutes = CACHE_TOTAL_MINUTES)
         {
-            var uri = new Uri(bundleUri);
-            var appBundleName = Path.GetFileName(uri.LocalPath);
-
-            if (Path.GetExtension(appBundleName) != ".zip")
-                appBundleName += ".zip";
-
-            var bundlePath = Path.Combine(tempFolder, appBundleName);
-
-            if (File.Exists(bundlePath))
+            if (!Uri.TryCreate(bundleUri, UriKind.RelativeOrAbsolute, out var uri))
             {
-                var lastTime = File.GetLastWriteTime(bundlePath);
-                var now = DateTime.Now;
-                var diff = now - lastTime;
-                if (diff.TotalMinutes < cacheTotalMinutes)
+                throw new ArgumentException("Invalid bundle URI.", nameof(bundleUri));
+            }
+
+            if (!uri.IsAbsoluteUri) // Relative URI
+            {
+                var appBundleName = Path.GetFileName(uri.OriginalString);
+                if (Path.GetExtension(appBundleName) != ".zip")
+                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
+
+                var bundlePath = Path.Combine(tempFolder, appBundleName);
+                var fullPath = Path.GetFullPath(uri.OriginalString);
+                if (File.Exists(fullPath))
                 {
+                    File.Copy(fullPath, bundlePath, true);
                     return bundlePath;
                 }
+                throw new FileNotFoundException("The specified local bundle file does not exist.", fullPath);
             }
-
-            if (File.Exists(uri.LocalPath))
+            else
             {
-                File.Copy(uri.LocalPath, bundlePath, true);
+                var appBundleName = Path.GetFileName(uri.LocalPath);
+
+                using var client = new HttpClient();
+                client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
+
+                if (string.IsNullOrWhiteSpace(authentication) == false)
+                    client.DefaultRequestHeaders.Add("Authorization", $"Bearer {authentication}");
+
+                var response = await client.GetAsync(bundleUri, HttpCompletionOption.ResponseHeadersRead);
+
+                // Total size (might be null if server doesn't send Content-Length)
+                var contentLengthHeader = response.Content.Headers.ContentLength;
+                var contentLength = contentLengthHeader.HasValue ? contentLengthHeader.Value : -1L;
+
+                // Check Content-Disposition
+                if (response.Content.Headers.ContentDisposition?.FileName is not null)
+                {
+                    appBundleName = response.Content.Headers.ContentDisposition.FileName.Trim('\"');
+                }
+
+                if (Path.GetExtension(appBundleName) != ".zip")
+                    throw new FileNotFoundException("The specified local bundle file does not have a .zip extension.", uri.OriginalString);
+
+                var bundlePath = Path.Combine(tempFolder, appBundleName);
+
+                //if (File.Exists(bundlePath))
+                //{
+                //    var lastTime = File.GetLastWriteTime(bundlePath);
+                //    var now = DateTime.Now;
+                //    var diff = now - lastTime;
+                //    if (diff.TotalMinutes < cacheTotalMinutes)
+                //    {
+                //        return bundlePath;
+                //    }
+                //}
+
+                await using var contentStream = await response.Content.ReadAsStreamAsync();
+                await using var fileStream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
+
+                var buffer = new byte[81920]; // 80 KB chunks
+                long totalRead = 0;
+                int read;
+                DownloadProgress?.Invoke(totalRead, contentLength);
+                do
+                {
+                    read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+                    if (read == 0) break;
+
+                    await fileStream.WriteAsync(buffer.AsMemory(0, read));
+                    totalRead += read;
+
+                    DownloadProgress?.Invoke(totalRead, contentLength);
+                } while (true);
+
                 return bundlePath;
             }
-
-            using var client = new HttpClient();
-            client.DefaultRequestHeaders.Add("User-Agent", "AppBundleTool");
-
-            if (string.IsNullOrWhiteSpace(authentication) == false)
-                client.DefaultRequestHeaders.Add("Authorization", $"Bearer {authentication}");
-
-            var response = await client.GetAsync(bundleUri, HttpCompletionOption.ResponseHeadersRead);
-
-            //using var fileStream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
-            //await response.Content.CopyToAsync(fileStream);
-
-            // Total size (might be null if server doesn't send Content-Length)
-            var contentLengthHeader = response.Content.Headers.ContentLength;
-            var contentLength = contentLengthHeader.HasValue ? contentLengthHeader.Value : -1L;
-
-            await using var contentStream = await response.Content.ReadAsStreamAsync();
-            await using var fileStream = new FileStream(bundlePath, FileMode.Create, FileAccess.Write, FileShare.None);
-
-            var buffer = new byte[81920]; // 80 KB chunks
-            long totalRead = 0;
-            int read;
-            DownloadProgress?.Invoke(totalRead, contentLength);
-            do
-            {
-                read = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length));
-                if (read == 0) break;
-
-                await fileStream.WriteAsync(buffer.AsMemory(0, read));
-                totalRead += read;
-
-                DownloadProgress?.Invoke(totalRead, contentLength);
-            } while (true);
-
-            return bundlePath;
         }
 
         /// <summary>

--- a/ricaun.AppBundleTool/Utils/NameAndVersionBundleUtils.cs
+++ b/ricaun.AppBundleTool/Utils/NameAndVersionBundleUtils.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace ricaun.AppBundleTool.Utils;
 
 /// <summary>
@@ -48,5 +50,42 @@ public static class NameAndVersionBundleUtils
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Removes the semantic version from a bundle file name while preserving the .bundle and .zip extensions.
+    /// </summary>
+    /// <param name="fileName">The file name from which to remove the version information.</param>
+    /// <returns>
+    /// The file name without the version information. If the file name matches the expected pattern,
+    /// returns the name with ".bundle" (and ".zip" if present). Otherwise, returns the original file name.
+    /// </returns>
+    /// <remarks>
+    /// This method handles both ".bundle" and ".bundle.zip" file extensions.
+    /// If the file has a ".zip" extension, it is preserved in the output.
+    /// </remarks>
+    /// <example>
+    /// Example usage:
+    /// <code>
+    /// string result1 = NameAndVersionBundleUtils.RemoveVersionBundle("MyApp.1.0.0.bundle.zip");
+    /// // result1 = "MyApp.bundle.zip"
+    /// 
+    /// string result2 = NameAndVersionBundleUtils.RemoveVersionBundle("MyApp.2.5.1-beta.bundle");
+    /// // result2 = "MyApp.bundle"
+    /// </code>
+    /// </example>
+    public static string RemoveVersionBundle(string fileName)
+    {
+        var extension = string.Empty;
+        if (Path.GetExtension(fileName) == ".zip")
+        {
+            extension = Path.GetExtension(fileName);
+            fileName = Path.GetFileNameWithoutExtension(fileName);
+        }
+        if (TryGetNameAndVersionBundle(fileName, out var name, out _))
+        {
+            return name + ".bundle" + extension;
+        }
+        return fileName + extension;
     }
 }


### PR DESCRIPTION
### Features
- Support download bundle with parameters in the url and local file path.
- Support download from redirect url and validate zip file. `BundleUri`
### Fixes
- Fix `Console` not supporting colors in some terminals. (Fix: #7)
### Updates
- Update `NameAndVersionBundleUtils` with `RemoveVersionBundle` to remove version from bundle file name.
- Update `BundleDownloadUtils` to support download url with parameters and local file path.
- Update `BundleDownloadUtils` to use `BundleUri` with handling local file or url.
- Update `BundleUri` to validate `zip` file when downloading from url.
### Tests
- Add `BundleDownloadTests` to test download url with parameters.
- Add `UriTests` to test uri with local files or urls.